### PR TITLE
Fix links in README.rst to new pypa/ locations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 install:
   - pip install -r test-requirements.txt
   - pip install .
-    
+
 python:
   - "3.4"
   - "3.5"
@@ -26,7 +26,7 @@ deploy:
   provider: pypi
   user: rmcgibbo
   password:
-    secure: YJZgHf2goWyGIrssg/yUb+bADcy1J7ieFv69TMfldhGKhSrtgksju43KygiD6nrjvW+LhhVGIJipIk6a5/IMzqNvngmeWa2CidZy4kIO411LsakI6L5TkyyjDvFW2BuCBaWyrsMUyoFCKgdgaiEaecF+exgXoT+pWmGKZKZSGCcWUB9PldugaYQWsutxKCbh8LfFGC8x59Ck4eT2xpx4lbFb+jlJU8ZK1acwTS1D+Qb2a+Fdtn527BqkD9pNyT0a7LXFbEuDtsWeSggzBdxfhOR+n27op32Zctb9OAjReHFtzymk16dH61UyXwP7hPzYGMmQhgtOK0i25ZRh/wn0kgpyCLlp2e4/SItHDjOEyaFvw+sh9aKqY4i8wIjV/U1YNqMba/pNYMIOIECRFJOuElKlPgUEGUMGUXGbnQcDDWfppKyLzayoo+CUL0v//uUSopLxkkHGcniUr2LX0IDk6ukbVc7E1NEZXuEK8PX/hC4SjoKcj1e//fyA36d1brDS3T5lvxkUBm0A29U0Gfh3WoW0BJ3Vc95D3PukvAMYm73mZZq1cKJIvB3ui/kHn3885JJl3Ae1PldJNiQLcjWj6piuXz+L08CMy+HXpWKT+tpCI/kJ9QoaE+afpX1yOi700K3ukiwG+hiTBsptD9IjggCavI5mjkDk42RguGBokgg=
+    secure: LOXMfae5B5cuY/FUQfGXAKFwScObvqPKCPF1prKFXhlGP+CjZZzCG7PmNwWKiVFWBYvHIzCCviKQ0FFtqLcxE79sCE6E6VXwUngSw39m5iOxubQaOi3GSTdzPCR/BFSE2iQR1/aBgmxui4NUY5lWjFhqtNSZo7YRacUYAViqSZop1manE7zO3FOhSA07ep7re2SM4vhIWDKwDLMToXfjSYWKtz4Yx0wEnNqNUDllKeOGSxQv1urEP5wd89o9xl6neGks4VuRfk9cqIkc23mKPN8T4xMmZnriMFnEFYI5sdApcr5+qBZWJpJL0o3Vo3iDmvUf3KqOIcXH3fMl1C9bdoE0PK0QRAircuwkuNYg3iOjkE6OLGaOuGjtYMhaWikiWCFGqtX8eMLHeoKEsAv2bvxYe14a9KE4lHOK9ooxlCuflG6I9CeS0Z8qlTSs+C0W2NLeqT2JFw1D4EFS5i/pJq1C5eMWUhTGkQFKme1cyX78+mWFNupQPQIYeMHihZxd9BJDTYP2jZz5JsZkWpV1/5OOB65hvEwRDLY37GbNmajnrL6auzSMJTx5brj5+pm3jtaQ47sBdrZ1bpmytjA/S6HYVCLbkn83aqqJLny1pidoRXatg5sg68Y0k/zcmGiQI4Bk6J8nQAUXO6/htPi9Wgm/1b10jh+7or/TRUihOhY=
   on:
     tags: true
-    repo: manylinux/auditwheel
+    repo: pypa/auditwheel

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 auditwheel
 ==========
 
-.. image:: https://travis-ci.org/manylinux/auditwheel.svg?branch=master
-    :target: https://travis-ci.org/manylinux/auditwheel
+.. image:: https://travis-ci.org/pypa/auditwheel.svg?branch=master
+    :target: https://travis-ci.org/pypa/auditwheel
 
 Auditing and relabeling `PEP 513 manylinux1 <https://www.python.org/dev/peps/pep-0513/>`_ Linux wheels.
 
@@ -37,7 +37,7 @@ But in general, building ``manylinux1`` wheels requires running on a CentOS5
 machine, so we recommend using the pre-built manylinux `Docker image
 <https://quay.io/repository/manylinux/manylinux?tag=latest>`_. ::
 
-  $ docker run -i -t -v `pwd`:/io quay.io/manylinux/manylinux /bin/bash
+  $ docker run -i -t -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /bin/bash
 
 
 Examples


### PR DESCRIPTION
Fixes #10. After a new release to PyPI, the links there (pulled from README) should be updated as well.