### PR TITLE
WIP: Update to latest PEP draft

### DIFF
--- a/auditwheel/elfutils.py
+++ b/auditwheel/elfutils.py
@@ -37,18 +37,6 @@ def elf_find_versioned_symbols(elf: ELFFile) -> Iterator[Tuple[str, str]]:
                        vernaux.name.decode('utf-8'))
 
 
-def elf_find_ucs2_symbols(elf: ELFFile) -> Iterator[str]:
-    section = elf.get_section_by_name(b'.dynsym')
-    if section is not None:
-        # look for UCS2 symbols that are externally referenced
-        for sym in section.iter_symbols():
-            if (b'PyUnicodeUCS2_' in sym.name and
-                    sym['st_shndx'] == 'SHN_UNDEF' and
-                    sym['st_info']['type'] == 'STT_FUNC'):
-
-                yield sym.name
-
-
 def elf_is_python_extension(fn, elf) -> Tuple[bool, Optional[int]]:
     modname = basename(fn).split('.', 1)[0]
     module_init_f = {'init' + modname: 2, 'PyInit_' + modname: 3}

--- a/auditwheel/main_show.py
+++ b/auditwheel/main_show.py
@@ -13,13 +13,16 @@ def printp(text):
 
 def execute(args, p):
     import json
+    import os
     from functools import reduce
     from collections import OrderedDict
     from os.path import isfile, basename
+    from wheel.install import WheelFile
     from .policy import (load_policies, get_priority_by_name,
                          POLICY_PRIORITY_LOWEST, POLICY_PRIORITY_HIGHEST,
                          get_policy_name)
     from .wheel_abi import analyze_wheel_abi
+    from .termcolor import colored
     fn = basename(args.WHEEL_FILE)
 
     if not isfile(args.WHEEL_FILE):
@@ -28,44 +31,55 @@ def execute(args, p):
     winfo = analyze_wheel_abi(args.WHEEL_FILE)
     versions = ['%s_%s' % (k, v) for k, v in winfo.versioned_symbols.items()]
 
-    printp('%s is consistent with the following platform tag: "%s".' %
-           (fn, winfo.overall_tag))
 
-    if get_priority_by_name(winfo.ucs_tag) < POLICY_PRIORITY_HIGHEST:
-        printp(('This wheel is compiled against a narrow unicode (UCS2) '
-                'version of Python, which is not compatible with the '
-                'manylinux1 tag.'))
-        if args.verbose < 1:
-            return
+    # WheelAbIInfo(overall_tag='linux_x86_64', external_refs={'linux_x86_64': {'libs': {'libffi.so.5': None, 'libpthread.so.0': '/lib/x86_64-linux-gnu/libpthread-2.21.so', 'libc.so.6': '/lib/x86_64-linux-gnu/libc-2.21.so'}, 'priority': 0}, 'manylinux1_x86_64': {'libs': {'libffi.so.5': None}, 'priority': 100}}, ref_tag='linux_x86_64', versioned_symbols={'GLIBC': NormalizedVersion('2.3')}, sym_tag='manylinux1_x86_64')
 
+    lines = ['Symbol Versioning',
+             '-----------------']
     if len(versions) == 0:
-        printp(("The wheel references no external versioned symbols from "
-                "system-provided shared libraries."))
+        lines.extend(["The wheel references no external versioned symbols from ",
+                      "system-provided shared libraries."])
     else:
-        printp('The wheel references the following external versioned '
-               'symbols in system-provided shared libraries: %s.' %
-               ', '.join(versions))
-
+        lines.extend(['The wheel references the following external versioned symbols in',
+                      'system-provided shared libraries: %s.' %
+                      ', '.join(versions)])
     if get_priority_by_name(winfo.sym_tag) < POLICY_PRIORITY_HIGHEST:
-        printp(('This constrains the platform tag to "%s". '
-                'In order to achieve a more compatible tag, you '
-                'would to recompile a new wheel from source on a system '
-                'with earlier versions of these libraries, such as '
-                'CentOS 5.') % winfo.sym_tag)
-        if args.verbose < 1:
-            return
+        lines.append(('This constrains the platform tag to "%s". '
+                      'In order to achieve a more compatible tag, you '
+                      'would to recompile a new wheel from source on a system '
+                      'with earlier versions of these libraries, such as '
+                      'CentOS 5.') % colored(winfo.sym_tag, color='red'))
+    else:
+        lines.append('This is %s with the manylinux1 tag.' % colored('consistent', color='green'))
 
+
+    lines.extend(['', 'External Libraries', '------------------'])
     libs = winfo.external_refs[get_policy_name(POLICY_PRIORITY_LOWEST)]['libs']
     if len(libs) == 0:
-        printp('The wheel requires no external shared libraries! :)')
+        lines.extend(['The wheel requires no external shared libraries! :).',
+                      'This is %s with the manylinux1 tag' % colored('consistent', color='green')])
     else:
-        printp(('The following external shared libraries are required '
-                'by the wheel:'))
-        print(json.dumps(OrderedDict(sorted(libs.items())), indent=4))
+         lines.append(('The following external shared libraries are required '
+                 'by the wheel:'))
+         lines.append(json.dumps(OrderedDict(sorted(libs.items())), indent=4))
+         lines.append('This is %s with the manylinux1 tag.' % colored('inconsistent', color='red')) 
 
     for p in sorted(load_policies(), key=lambda p: p['priority']):
         if p['priority'] > get_priority_by_name(winfo.overall_tag):
-            printp(('In order to achieve the tag platform tag "%s" '
-                    'the following shared library dependencies '
-                    'will need to be eliminated:') % p['name'])
-            printp(', '.join(sorted(winfo.external_refs[p['name']]['libs'].keys())))
+            lines.extend(['In order to achieve the tag platform tag "%s" the following' % p['name'],
+                          'shared library dependencies will need to be eliminated:'])
+            lines.append(', '.join(sorted(winfo.external_refs[p['name']]['libs'].keys())))
+
+
+    lines.extend(['', 'Unicode', '-------'])
+
+    wheel = WheelFile(args.WHEEL_FILE)
+    if any(pyver.startswith('cp2') or pyver in ('cp30', 'cp31', 'cp32') and abi is 'none' for (pyver, abi, plat) in wheel.tags):
+        lines.extend(['This wheel has a "none" ABI tag. Rebuild with the latest',
+                      'release of ``pip install wheel`` to fix. This is %s' % colored('inconsistent', color='red'),
+                      'with the manylinux1 tag.'])
+    else:
+        lines.extend(['The unicode ABI is properly declared.',
+                      'This is %s with the manylinux1 tag' % colored('consistent', color='green')])
+
+    print(os.linesep.join(lines))

--- a/auditwheel/termcolor.py
+++ b/auditwheel/termcolor.py
@@ -1,0 +1,168 @@
+# coding: utf-8
+# Copyright (c) 2008-2011 Volvox Development Team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# Author: Konstantin Lepa <konstantin.lepa@gmail.com>
+
+"""ANSII Color formatting for output in terminal."""
+
+from __future__ import print_function
+import os
+
+
+__ALL__ = [ 'colored', 'cprint' ]
+
+VERSION = (1, 1, 0)
+
+ATTRIBUTES = dict(
+        list(zip([
+            'bold',
+            'dark',
+            '',
+            'underline',
+            'blink',
+            '',
+            'reverse',
+            'concealed'
+            ],
+            list(range(1, 9))
+            ))
+        )
+del ATTRIBUTES['']
+
+
+HIGHLIGHTS = dict(
+        list(zip([
+            'on_grey',
+            'on_red',
+            'on_green',
+            'on_yellow',
+            'on_blue',
+            'on_magenta',
+            'on_cyan',
+            'on_white'
+            ],
+            list(range(40, 48))
+            ))
+        )
+
+
+COLORS = dict(
+        list(zip([
+            'grey',
+            'red',
+            'green',
+            'yellow',
+            'blue',
+            'magenta',
+            'cyan',
+            'white',
+            ],
+            list(range(30, 38))
+            ))
+        )
+
+
+RESET = '\033[0m'
+
+
+def colored(text, color=None, on_color=None, attrs=None):
+    """Colorize text.
+
+    Available text colors:
+        red, green, yellow, blue, magenta, cyan, white.
+
+    Available text highlights:
+        on_red, on_green, on_yellow, on_blue, on_magenta, on_cyan, on_white.
+
+    Available attributes:
+        bold, dark, underline, blink, reverse, concealed.
+
+    Example:
+        colored('Hello, World!', 'red', 'on_grey', ['blue', 'blink'])
+        colored('Hello, World!', 'green')
+    """
+    if os.getenv('ANSI_COLORS_DISABLED') is None:
+        fmt_str = '\033[%dm%s'
+        if color is not None:
+            text = fmt_str % (COLORS[color], text)
+
+        if on_color is not None:
+            text = fmt_str % (HIGHLIGHTS[on_color], text)
+
+        if attrs is not None:
+            for attr in attrs:
+                text = fmt_str % (ATTRIBUTES[attr], text)
+
+        text += RESET
+    return text
+
+
+def cprint(text, color=None, on_color=None, attrs=None, **kwargs):
+    """Print colorize text.
+
+    It accepts arguments of print function.
+    """
+
+    print((colored(text, color, on_color, attrs)), **kwargs)
+
+
+if __name__ == '__main__':
+    print('Current terminal type: %s' % os.getenv('TERM'))
+    print('Test basic colors:')
+    cprint('Grey color', 'grey')
+    cprint('Red color', 'red')
+    cprint('Green color', 'green')
+    cprint('Yellow color', 'yellow')
+    cprint('Blue color', 'blue')
+    cprint('Magenta color', 'magenta')
+    cprint('Cyan color', 'cyan')
+    cprint('White color', 'white')
+    print(('-' * 78))
+
+    print('Test highlights:')
+    cprint('On grey color', on_color='on_grey')
+    cprint('On red color', on_color='on_red')
+    cprint('On green color', on_color='on_green')
+    cprint('On yellow color', on_color='on_yellow')
+    cprint('On blue color', on_color='on_blue')
+    cprint('On magenta color', on_color='on_magenta')
+    cprint('On cyan color', on_color='on_cyan')
+    cprint('On white color', color='grey', on_color='on_white')
+    print('-' * 78)
+
+    print('Test attributes:')
+    cprint('Bold grey color', 'grey', attrs=['bold'])
+    cprint('Dark red color', 'red', attrs=['dark'])
+    cprint('Underline green color', 'green', attrs=['underline'])
+    cprint('Blink yellow color', 'yellow', attrs=['blink'])
+    cprint('Reversed blue color', 'blue', attrs=['reverse'])
+    cprint('Concealed Magenta color', 'magenta', attrs=['concealed'])
+    cprint('Bold underline reverse cyan color', 'cyan',
+            attrs=['bold', 'underline', 'reverse'])
+    cprint('Dark blink concealed white color', 'white',
+            attrs=['dark', 'blink', 'concealed'])
+    print(('-' * 78))
+
+    print('Test mixing:')
+    cprint('Underline red on grey color', 'red', 'on_grey',
+            ['underline'])
+    cprint('Reversed green on red color', 'green', 'on_red', ['reverse'])
+

--- a/auditwheel/wheel_abi.py
+++ b/auditwheel/wheel_abi.py
@@ -8,7 +8,7 @@ from collections import defaultdict, Mapping, Sequence, namedtuple
 from .genericpkgctx import InGenericPkgCtx
 from .lddtree import lddtree
 from .elfutils import (elf_file_filter, elf_find_versioned_symbols,
-                       elf_find_ucs2_symbols, elf_is_python_extension)
+                       elf_is_python_extension)
 from .policy import (lddtree_external_references, versioned_symbols_policy,
                      max_versioned_symbol, get_policy_name,
                      POLICY_PRIORITY_LOWEST, POLICY_PRIORITY_HIGHEST,
@@ -17,7 +17,7 @@ from .policy import (lddtree_external_references, versioned_symbols_policy,
 log = logging.getLogger(__name__)
 WheelAbIInfo = namedtuple('WheelAbIInfo',
                           ['overall_tag', 'external_refs', 'ref_tag',
-                           'versioned_symbols', 'sym_tag', 'ucs_tag'])
+                           'versioned_symbols', 'sym_tag'])
 
 
 @functools.lru_cache()
@@ -25,7 +25,6 @@ def get_wheel_elfdata(wheel_fn: str):
     full_elftree = {}
     full_external_refs = {}
     versioned_symbols = defaultdict(lambda: set())  # type: Dict[str, Set[str]]
-    uses_ucs2_symbols = False
 
     with InGenericPkgCtx(wheel_fn) as ctx:
         for fn, elf in elf_file_filter(ctx.iter_files()):
@@ -37,15 +36,12 @@ def get_wheel_elfdata(wheel_fn: str):
                 for key, value in elf_find_versioned_symbols(elf):
                     versioned_symbols[key].add(value)
 
-                if py_ver == 2:
-                    uses_ucs2_symbols |= any(
-                        True for _ in elf_find_ucs2_symbols(elf))
                 full_external_refs[fn] = lddtree_external_references(elftree,
                                                                      ctx.path)
 
     log.debug(json.dumps(full_elftree, indent=4))
     return (full_elftree, full_external_refs,
-            max_versioned_symbol(versioned_symbols), uses_ucs2_symbols)
+            max_versioned_symbol(versioned_symbols))
 
 
 def analyze_wheel_abi(wheel_fn: str):
@@ -55,8 +51,7 @@ def analyze_wheel_abi(wheel_fn: str):
         for p in load_policies()
     }
 
-    elftree_by_fn, external_refs_by_fn, versioned_symbols, has_ucs2 = \
-            get_wheel_elfdata(wheel_fn)
+    elftree_by_fn, external_refs_by_fn, versioned_symbols =  get_wheel_elfdata(wheel_fn)
 
     for fn, elftree in elftree_by_fn.items():
         update(external_refs, external_refs_by_fn[fn])
@@ -70,18 +65,11 @@ def analyze_wheel_abi(wheel_fn: str):
         (e['priority'] for e in external_refs.values() if len(e['libs']) == 0),
         default=POLICY_PRIORITY_LOWEST)
 
-    if has_ucs2:
-        ucs_policy = POLICY_PRIORITY_LOWEST
-    else:
-        ucs_policy = POLICY_PRIORITY_HIGHEST
-
     ref_tag = get_policy_name(ref_policy)
     sym_tag = get_policy_name(symbol_policy)
-    ucs_tag = get_policy_name(ucs_policy)
-    overall_tag = get_policy_name(min(symbol_policy, ref_policy, ucs_policy))
+    overall_tag = get_policy_name(min(symbol_policy, ref_policy))
 
-    return WheelAbIInfo(overall_tag, external_refs, ref_tag, versioned_symbols,
-                        sym_tag, ucs_tag)
+    return WheelAbIInfo(overall_tag, external_refs, ref_tag, versioned_symbols, sym_tag)
 
 
 def update(d, u):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 setuptools
-wheel >= 0.26.0
+wheel >= 0.29.0
 typing >=3.5.0.1
 pyelftools >=0.23


### PR DESCRIPTION
Currently chages `auditwheel show` output to something like

```
$ auditwheel show tests/cffi-1.5.0-cp27-none-linux_x86_64.whl
Symbol Versioning
-----------------
The wheel references the following external versioned symbols in
system-provided shared libraries: GLIBC_2.3.
This is consistent with the manylinux1 tag.

External Libraries
------------------
The following external shared libraries are required by the wheel:
{
    "libc.so.6": "/lib/x86_64-linux-gnu/libc-2.21.so",
    "libffi.so.5": null,
    "libpthread.so.0": "/lib/x86_64-linux-gnu/libpthread-2.21.so"
}
This is inconsistent with the manylinux1 tag.
In order to achieve the tag platform tag "manylinux1_x86_64" the following
shared library dependencies will need to be eliminated:
libffi.so.5

Unicode
-------
This wheel has a "none" ABI tag. Rebuild with the latest
release of ``pip install wheel`` to fix. This is inconsistent
with the manylinux1 tag.
```
