### PR TITLE
[MRG] Update the wheel tags when repairing

### DIFF
--- a/auditwheel/main_addtag.py
+++ b/auditwheel/main_addtag.py
@@ -4,8 +4,6 @@ from .policy import (load_policies, get_policy_name, get_priority_by_name,
 
 
 def configure_parser(sub_parsers):
-    policy_names = [p['name'] for p in load_policies()]
-    highest_policy = get_policy_name(POLICY_PRIORITY_HIGHEST)
     help = "Add new platform ABI tags to a wheel"
 
     p = sub_parsers.add_parser('addtag', help=help, description=help)
@@ -55,5 +53,5 @@ def execute(args, p):
             # tell context manager to write wheel on exit with
             # the proper output directory
             ctx.out_wheel = join(args.WHEEL_DIR, basename(out_wheel))
-
+            print('\nUpdated wheel written to %s' % out_wheel)
     return 0

--- a/auditwheel/main_repair.py
+++ b/auditwheel/main_repair.py
@@ -32,6 +32,12 @@ def configure_parser(sub_parsers):
                    help=('Directory to store delocated wheels (default:'
                          ' "wheelhouse/")'),
                    default='wheelhouse/')
+    p.add_argument('--no-update-tags',
+                   dest='UPDATE_TAGS',
+                   action='store_false',
+                   help=('Do not update the wheel filename tags and WHEEL info'
+                         ' to match the repaired platform tag.'),
+                   default=True)
     p.set_defaults(func=execute)
 
 
@@ -71,7 +77,8 @@ def execute(args, p):
     out_wheel = repair_wheel(args.WHEEL_FILE,
                              abi=args.PLAT,
                              lib_sdir=args.LIB_SDIR,
-                             out_dir=args.WHEEL_DIR)
+                             out_dir=args.WHEEL_DIR,
+                             update_tags=args.UPDATE_TAGS)
 
     if out_wheel is not None:
-        print('\nWriting fixed-up wheel written to %s' % out_wheel)
+        print('\nFixed-up wheel written to %s' % out_wheel)

--- a/auditwheel/policy/__init__.py
+++ b/auditwheel/policy/__init__.py
@@ -14,6 +14,11 @@ platform = _sys_map.get(sys.platform, 'unknown')
 bits = 8 * tuple.__itemsize__
 linkage = _platform_module.architecture()[1]
 
+_PLATFORM_REPLACEMENT_MAP = {
+    'manylinux1_x86_64': ['linux_x86_64'],
+    'manylinux1_i686': ['linux_i686'],
+}
+
 # XXX: this could be weakened. The show command _could_ run on OS X or
 # Windows probably, but there's not much reason to inspect foreign package
 # that won't run on the platform.
@@ -28,15 +33,20 @@ if platform != 'linux':
 #         file=sys.stderr)
 #     sys.exit(1)
 
-if _platform_module.machine() in non_x86_linux_machines:
-    arch_name = _platform_module.machine()
-else:
-    arch_name = {64: 'x86_64', 32: '_i386'}[bits]
+
+def get_arch_name():
+    if _platform_module.machine() in non_x86_linux_machines:
+        return _platform_module.machine()
+    else:
+        return {64: 'x86_64', 32: '_i686'}[bits]
+
+_ARCH_NAME = get_arch_name()
+
 
 with open(join(dirname(abspath(__file__)), 'policy.json')) as f:
     _POLICIES = json.load(f)
     for p in _POLICIES:
-        p['name'] = p['name'] + '_' + arch_name
+        p['name'] = p['name'] + '_' + _ARCH_NAME
 
 POLICY_PRIORITY_HIGHEST = max(p['priority'] for p in _POLICIES)
 POLICY_PRIORITY_LOWEST = min(p['priority'] for p in _POLICIES)
@@ -66,13 +76,29 @@ def get_priority_by_name(name: str):
     if len(matches) == 0:
         return None
     if len(matches) > 1:
-        raise RuntimeError('Internal error. priorities should be unique')
+        raise RuntimeError('Internal error. Policies should be unique.')
     return matches[0]
+
+
+def get_replace_platforms(name: str):
+    """Extract platform tag replacement rules from policy
+
+    >>> get_replace_platforms('linux_x86_64')
+    []
+    >>> get_replace_platforms('linux_i686')
+    []
+    >>> get_replace_platforms('manylinux1_x86_64')
+    ['linux_x86_64']
+    >>> get_replace_platforms('manylinux1_i686')
+    ['linux_i686']
+
+    """
+    return _PLATFORM_REPLACEMENT_MAP.get(name, [])
 
 
 from .external_references import lddtree_external_references
 from .versioned_symbols import versioned_symbols_policy, max_versioned_symbol
 
 __all__ = ['lddtree_external_references', 'versioned_symbols_policy',
-           'max_versioned_symbol', 'load_policy', 'POLICY_PRIORITY_HIGHEST',
+           'max_versioned_symbol', 'load_policies', 'POLICY_PRIORITY_HIGHEST',
            'POLICY_PRIORITY_LOWEST']

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ envlist = py34,py35
 [testenv]
 deps = .
        -r{toxinidir}/test-requirements.txt
-commands =  py.test []
+commands =  py.test --doctest-modules auditwheel tests


### PR DESCRIPTION
This is a fix for #19. auditwheel repair now automatically update the filename and `WHEEL`'s 'Tag' entry to remove the old `linux` platform tags and replace them with the matching `manylinux1` tags to make the wheel suitable for upload to PyPI.

Here is an example run on a numpy wheel built using the manylinux docker image and @matthew-brett's ATLAS rpms:

```
# /opt/3.5m/bin/auditwheel repair numpy-1.10.4-cp35-cp35m-linux_x86_64.whl
Repairing numpy-1.10.4-cp35-cp35m-linux_x86_64.whl
Grafting: /usr/lib64/atlas/libtatlas.so.3.10
Grafting: /usr/lib64/libgfortran.so.3.0.0
Setting RPATH: numpy/linalg/_umath_linalg.cpython-35m-x86_64-linux-gnu.so to "$ORIGIN/../.libs"
Setting RPATH: numpy/core/multiarray.cpython-35m-x86_64-linux-gnu.so to "$ORIGIN/../.libs"
Setting RPATH: numpy/linalg/lapack_lite.cpython-35m-x86_64-linux-gnu.so to "$ORIGIN/../.libs"
Previous filename tags: linux_x86_64
New filename tags: manylinux1_x86_64
Previous WHEEL info tags: cp35-cp35m-linux_x86_64
New WHEEL info tags: cp35-cp35m-manylinux1_x86_64

Fixed-up wheel written to /root/wheelhouse/numpy-1.10.4-cp35-cp35m-manylinux1_x86_64.whl
```

cc @rmcgibbo @njsmith 