### PR TITLE
fix invalid manylinux wheel filename for 32 bits platform

### DIFF
--- a/auditwheel/policy/__init__.py
+++ b/auditwheel/policy/__init__.py
@@ -38,7 +38,7 @@ def get_arch_name():
     if _platform_module.machine() in non_x86_linux_machines:
         return _platform_module.machine()
     else:
-        return {64: 'x86_64', 32: '_i686'}[bits]
+        return {64: 'x86_64', 32: 'i686'}[bits]
 
 _ARCH_NAME = get_arch_name()
 


### PR DESCRIPTION
When repairing Python wheel on 32 bits linux, the resulting wheel file ends suffixed in a wrong way : 'manylinux1__i686' instead of 'manylinux1_i686'. The problem comes from the get_arch_name in the policy sub module, looks like a typo to me.