### PR TITLE
allow to repair other shared libraries bundled in a wheel

### DIFF
--- a/auditwheel/repair.py
+++ b/auditwheel/repair.py
@@ -92,12 +92,13 @@ def repair_wheel(wheel_path: str, abi: str, lib_sdir: str, out_dir: str,
         # we grafted in a bunch of libraries and modifed their sonames, but
         # they may have internal dependencies (DT_NEEDED) on one another, so
         # we need to update those records so each now knows about the new
-        # name of the other.
+        # name of the other but also its location by adding rpath.
         for old_soname, (new_soname, path) in soname_map.items():
             needed = elf_read_dt_needed(path)
             for n in needed:
                 if n in soname_map:
                     check_call(['patchelf', '--replace-needed', n, soname_map[n][0], path])
+                    patchelf_set_rpath(path, dirname(soname_map[n][1]))
 
         if update_tags:
             ctx.out_wheel = add_platforms(ctx, [abi],

--- a/auditwheel/wheel_abi.py
+++ b/auditwheel/wheel_abi.py
@@ -29,18 +29,18 @@ def get_wheel_elfdata(wheel_fn: str):
     with InGenericPkgCtx(wheel_fn) as ctx:
         for fn, elf in elf_file_filter(ctx.iter_files()):
             is_py_ext, py_ver = elf_is_python_extension(fn, elf)
-            if is_py_ext:
-                log.info('processing: %s', fn)
-                elftree = lddtree(fn)
-                full_elftree[fn] = elftree
-                for key, value in elf_find_versioned_symbols(elf):
-                    versioned_symbols[key].add(value)
 
-                if py_ver == 2:
-                    uses_ucs2_symbols |= any(
-                        True for _ in elf_find_ucs2_symbols(elf))
-                full_external_refs[fn] = lddtree_external_references(elftree,
-                                                                     ctx.path)
+            log.info('processing: %s', fn)
+            elftree = lddtree(fn)
+            full_elftree[fn] = elftree
+            for key, value in elf_find_versioned_symbols(elf):
+                versioned_symbols[key].add(value)
+
+            if is_py_ext and py_ver == 2:
+                uses_ucs2_symbols |= any(
+                    True for _ in elf_find_ucs2_symbols(elf))
+            full_external_refs[fn] = lddtree_external_references(elftree,
+                                                                 ctx.path)
 
     log.debug(json.dumps(full_elftree, indent=4))
 


### PR DESCRIPTION
First, thanks for the great work on the PEP 513 and the auditwheel tool. Being able to upload binary wheels for Linux platforms was a real missing feature.

I work on an opensource project called Tulip (http://www.tulip-software.org) mainly dedicated to the visualization of large graphs. The project is written in C++ but we also offered Python bindings to our core libraries (https://pypi.python.org/pypi/tulip-python). I already managed to distribute wheels of our modules for Windows and MacOS, so when I heard about the PEP 513, I gave it a try.

So I used the Centos5 docker images to compile our project and its Python bindings. When trying to use the auditwheel tool to repair the wheels we produce, I came into some small issues. 

I use a different method to generate the binary wheels through the 'setup.py bdist_wheel' command.
I compile Tulip and its Python bindings through the use of CMake, put all the files required to distribute the modules (Python extension modules + shared libraries related to our project) in a directory, and then use 'setup.py bdist_wheel' command to bundle the whole in a .whl archive. As I need the wheels to get the correct binary tag name (e.g. cp27-cp27m-linux-x86_64) and I don't compile the extension modules trough 'setup.py', I am forced to override the distclass in the setup function (see https://github.com/tulip5/tulip/blob/master/library/tulip-python/bindings/tulip-core/packaging/setup.py.in). Proceeding that way, bundled modules are not located in the root folder of the wheel but in the purelib folder inside the modules data folder (check the wheels I uploaded on PyPi). Consequently, the auditwheel tool fails to find the module root folder. I added some checks in 'repair.py' to handle that special case. 

I also distribute other shared libraries in the wheels for the Tulip modules (tulip libraries + some its plugins). The auditwheel tool don't take into account shared libraries bundled into a wheel different from Python extension modules in its repairing tasks. But they must also be repaired in order to be distributed. I slightly modify the 'get_wheel_elfdata' function in wheel_abi.py to also allow those libraries to be fixed through the patchelf tool.

Besides those small issues, the produced wheels works great on every Linux distributions I have tested so far.
