### PR TITLE
support pyelftools-0.24

### DIFF
--- a/auditwheel/elfutils.py
+++ b/auditwheel/elfutils.py
@@ -11,13 +11,13 @@ def elf_read_dt_needed(fn : str) -> List[str]:
     needed = []
     with open(fn, 'rb') as f:
         elf = ELFFile(f)
-        section = elf.get_section_by_name(b'.dynamic')
+        section = elf.get_section_by_name('.dynamic')
         if section is None:
             raise ValueError('Could not find soname in %s' % fn)
 
         for t in section.iter_tags():
             if t.entry.d_tag == 'DT_NEEDED':
-                needed.append(t.needed.decode('utf-8'))
+                needed.append(t.needed)
 
     return needed
 
@@ -41,23 +41,23 @@ def elf_file_filter(paths: Iterator[str]) -> Iterator[Tuple[str, ELFFile]]:
 
 
 def elf_find_versioned_symbols(elf: ELFFile) -> Iterator[Tuple[str, str]]:
-    section = elf.get_section_by_name(b'.gnu.version_r')
+    section = elf.get_section_by_name('.gnu.version_r')
 
     if section is not None:
         for verneed, verneed_iter in section.iter_versions():
-            if verneed.name.decode('utf-8').startswith('ld-linux'):
+            if verneed.name.startswith('ld-linux'):
                 continue
             for vernaux in verneed_iter:
-                yield (verneed.name.decode('utf-8'),
-                       vernaux.name.decode('utf-8'))
+                yield (verneed.name,
+                       vernaux.name)
 
 
 def elf_find_ucs2_symbols(elf: ELFFile) -> Iterator[str]:
-    section = elf.get_section_by_name(b'.dynsym')
+    section = elf.get_section_by_name('.dynsym')
     if section is not None:
         # look for UCS2 symbols that are externally referenced
         for sym in section.iter_symbols():
-            if (b'PyUnicodeUCS2_' in sym.name and
+            if ('PyUnicodeUCS2_' in sym.name and
                     sym['st_shndx'] == 'SHN_UNDEF' and
                     sym['st_info']['type'] == 'STT_FUNC'):
 
@@ -68,16 +68,16 @@ def elf_is_python_extension(fn, elf) -> Tuple[bool, Optional[int]]:
     modname = basename(fn).split('.', 1)[0]
     module_init_f = {'init' + modname: 2, 'PyInit_' + modname: 3}
 
-    sect = elf.get_section_by_name(b'.dynsym')
+    sect = elf.get_section_by_name('.dynsym')
     if sect is None:
         return False, None
 
     for sym in sect.iter_symbols():
-        if (sym.name.decode('utf-8') in module_init_f and
+        if (sym.name in module_init_f and
                 sym['st_shndx'] != 'SHN_UNDEF' and
                 sym['st_info']['type'] == 'STT_FUNC'):
 
-            return True, module_init_f[sym.name.decode('utf-8')]
+            return True, module_init_f[sym.name]
 
     return False, None
 
@@ -87,19 +87,19 @@ def elf_read_rpaths(fn: str) -> Dict[str, List[str]]:
 
     with open(fn, 'rb') as f:
         elf = ELFFile(f)
-        section = elf.get_section_by_name(b'.dynamic')
+        section = elf.get_section_by_name('.dynamic')
         if section is None:
             return result
 
         for t in section.iter_tags():
             if t.entry.d_tag == 'DT_RPATH':
                 result['rpaths'] = parse_ld_paths(
-                    t.rpath.decode('utf-8'),
+                    t.rpath,
                     root='/',
                     path=fn)
             elif t.entry.d_tag == 'DT_RUNPATH':
                 result['runpaths'] = parse_ld_paths(
-                    t.runpath.decode('utf-8'),
+                    t.runpath,
                     root='/',
                     path=fn)
 

--- a/auditwheel/lddtree.py
+++ b/auditwheel/lddtree.py
@@ -342,7 +342,7 @@ def lddtree(path: str,
                 if segment.header.p_type != 'PT_INTERP':
                     continue
 
-                interp = segment.get_interp_name().decode('utf-8')
+                interp = segment.get_interp_name()
                 log.debug('  interp           = %s', interp)
                 ret['interp'] = normpath(root + interp)
                 ret['libs'][os.path.basename(interp)] = {
@@ -372,16 +372,16 @@ def lddtree(path: str,
             for t in segment.iter_tags():
                 if t.entry.d_tag == 'DT_RPATH':
                     rpaths = parse_ld_paths(
-                        t.rpath.decode('utf-8'),
+                        t.rpath,
                         root=root,
                         path=path)
                 elif t.entry.d_tag == 'DT_RUNPATH':
                     runpaths = parse_ld_paths(
-                        t.runpath.decode('utf-8'),
+                        t.runpath,
                         root=root,
                         path=path)
                 elif t.entry.d_tag == 'DT_NEEDED':
-                    libs.append(t.needed.decode('utf-8'))
+                    libs.append(t.needed)
             if runpaths:
                 # If both RPATH and RUNPATH are set, only the latter is used.
                 rpaths = []

--- a/auditwheel/repair.py
+++ b/auditwheel/repair.py
@@ -32,7 +32,7 @@ def verify_patchelf():
     m = re.match('patchelf\s+(\d+(.\d+)?)', version)
     if m and tuple(int(x) for x in m.group(1).split('.')) >= (0, 9):
         return
-    raise ValueError(('patchelf %s found. auditwheel repair requires'
+    raise ValueError(('patchelf %s found. auditwheel repair requires '
                       'patchelf >= 0.9.') %
                      version)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 setuptools
 wheel >= 0.26.0
 typing >=3.5.0.1
-pyelftools >=0.23
+pyelftools >=0.24

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 jsonschema
+numpy
 pypatchelf

--- a/tests/test_bundled_cffi.py
+++ b/tests/test_bundled_cffi.py
@@ -1,0 +1,8 @@
+from auditwheel.wheel_abi import analyze_wheel_abi
+
+
+def test_analyze_wheel_abi():
+    winfo = analyze_wheel_abi('tests/cffi-1.5.0-cp27-none-linux_x86_64.whl')
+    external_libs = winfo.external_refs['manylinux1_x86_64']['libs']
+    assert len(external_libs) > 0
+    assert set(external_libs) == {'libffi.so.5'}


### PR DESCRIPTION
In that version symbol and section names are strings, not bytes, fixes #49.

Also some cosmetic changes - added required test dependencies and fixed typo in error message relating patchelf version.