### PR TITLE
Fix versioned symbol policy check

### DIFF
--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,5 +1,6 @@
 from jsonschema import validate
-from auditwheel.policy import load_policies, _load_policy_schema
+from auditwheel.policy import (load_policies, _load_policy_schema,
+                               versioned_symbols_policy, POLICY_PRIORITY_LOWEST)
 
 
 def test_policy():
@@ -7,3 +8,9 @@ def test_policy():
     policy_schema = _load_policy_schema()
     validate(policy, policy_schema)
 
+
+def test_policy_checks_glibc():
+    policy = versioned_symbols_policy({"some_library.so": {"GLIBC_2.5"}})
+    assert policy > POLICY_PRIORITY_LOWEST
+    policy = versioned_symbols_policy({"some_library.so": {"GLIBC_999"}})
+    assert policy == POLICY_PRIORITY_LOWEST


### PR DESCRIPTION
policy_is_satisfied always returned True.

show output before:
```
The wheel references external versioned symbols in these system-
provided shared libraries: libQt5Gui.so.5 with versions {'Qt_5'},
libQt5PrintSupport.so.5 with versions {'Qt_5'}, libc.so.6 with
versions {'GLIBC_2.2.5', 'GLIBC_2.3', 'GLIBC_2.4', 'GLIBC_2.3.4',
'GLIBC_2.14'}, libstdc++.so.6 with versions {'GLIBCXX_3.4.21',
'CXXABI_1.3', 'GLIBCXX_3.4.20', 'GLIBCXX_3.4'}, libm.so.6 with
versions {'GLIBC_2.2.5'}, libgcc_s.so.1 with versions {'GCC_3.0'},
libQt5Core.so.5 with versions {'Qt_5.7', 'Qt_5'}, libQt5Widgets.so.5
with versions {'Qt_5'}

The following external shared libraries are required by the wheel:
```

show output after:
```
DEBUG:auditwheel.policy.versioned_symbols:Package requires GLIBCXX_3.4.20, incompatible with policy manylinux1_i686 which requires {'GLIBCXX_3.4', 'GLIBCXX_3.4.4', 'GLIBCXX_3.4.6', 'GLIBCXX_3.4.1', 'GLIBCXX_3.4.8', 'GLIBCXX_3.4.7', 'GLIBCXX_3.4.5', 'GLIBCXX_3.4.2', 'GLIBCXX_3.4.3'}
DEBUG:auditwheel.policy.versioned_symbols:Package requires GLIBCXX_3.4.21, incompatible with policy manylinux1_i686 which requires {'GLIBCXX_3.4', 'GLIBCXX_3.4.4', 'GLIBCXX_3.4.6', 'GLIBCXX_3.4.1', 'GLIBCXX_3.4.8', 'GLIBCXX_3.4.7', 'GLIBCXX_3.4.5', 'GLIBCXX_3.4.2', 'GLIBCXX_3.4.3'}
DEBUG:auditwheel.policy.versioned_symbols:Package requires GLIBC_2.14, incompatible with policy manylinux1_i686 which requires {'GLIBC_2.1', 'GLIBC_2.1.3', 'GLIBC_2.2.2', 'GLIBC_2.5', 'GLIBC_2.1.2', 'GLIBC_2.2.5', 'GLIBC_2.2.1', 'GLIBC_2.3.3', 'GLIBC_2.3.4', 'GLIBC_2.3.2', 'GLIBC_2.2.3', 'GLIBC_2.1.1', 'GLIBC_2.0', 'GLIBC_2.2.4', 'GLIBC_2.4', 'GLIBC_2.2', 'GLIBC_2.3', 'GLIBC_2.2.6'}

The wheel references external versioned symbols in these system-
provided shared libraries: libgcc_s.so.1 with versions {'GCC_3.0'},
libQt5PrintSupport.so.5 with versions {'Qt_5'}, libQt5Gui.so.5 with
versions {'Qt_5'}, libQt5Core.so.5 with versions {'Qt_5.7', 'Qt_5'},
libc.so.6 with versions {'GLIBC_2.3.4', 'GLIBC_2.4', 'GLIBC_2.14',
'GLIBC_2.2.5', 'GLIBC_2.3'}, libQt5Widgets.so.5 with versions
{'Qt_5'}, libstdc++.so.6 with versions {'CXXABI_1.3',
'GLIBCXX_3.4.20', 'GLIBCXX_3.4.21', 'GLIBCXX_3.4'}, libm.so.6 with
versions {'GLIBC_2.2.5'}

This constrains the platform tag to "linux_i686". In order to achieve
a more compatible tag, you would to recompile a new wheel from source
on a system with earlier versions of these libraries, such as CentOS
5.

The following external shared libraries are required by the wheel:
```

A bad wheel, for testing: https://pypi.python.org/packages/de/50/67caccd90aeb7814ce50dea4e558e9acf27a76539f199a303a18dff05730/QScintilla-2.9.3-cp35-cp35m-manylinux1_x86_64.whl