### PR TITLE
Add PPC64le policy architecture

### DIFF
--- a/auditwheel/policy/__init__.py
+++ b/auditwheel/policy/__init__.py
@@ -44,7 +44,11 @@ _ARCH_NAME = get_arch_name()
 
 
 with open(join(dirname(abspath(__file__)), 'policy.json')) as f:
-    _POLICIES = json.load(f)
+    _ALL_POLICIES = json.load(f)
+    _POLICIES = []
+    for p in _ALL_POLICIES:
+        if (_platform_module.machine() in p["architecture"]):
+            _POLICIES.append(p)
     for p in _POLICIES:
         p['name'] = p['name'] + '_' + _ARCH_NAME
 

--- a/auditwheel/policy/policy.json
+++ b/auditwheel/policy/policy.json
@@ -1,10 +1,12 @@
 [
     {"name": "linux",
+     "architecture": ["ppc64le", "x86_64"],
      "priority": 0,
      "symbol_versions": {},
      "lib_whitelist": []
     },
     {"name": "manylinux1",
+     "architecture": ["x86_64"],
      "priority": 100,
      "symbol_versions": {
          "GLIBC": ["2.0", "2.1", "2.1.1", "2.1.2", "2.1.3", "2.2", "2.2.1",
@@ -25,5 +27,24 @@
          "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6",
          "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0",
          "libgthread-2.0.so.0", "libglib-2.0.so.0"
+     ]},
+    {"name": "manylinux1",
+     "architecture": ["ppc64le"],
+     "priority": 100,
+     "symbol_versions": {
+         "GLIBC": ["2.17"],
+         "CXXABI": [],
+         "GLIBCXX": [],
+         "GCC": []
+     },
+     "lib_whitelist": [
+         "libpanelw.so.5", "libncursesw.so.5",
+         "libgcc_s.so.1",
+         "libstdc++.so.6",
+         "libm.so.6", "libdl.so.2", "librt.so.1", "libcrypt.so.1",
+         "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0",
+         "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6",
+         "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0",
+         "libgthread-2.0.so.0", "libglib-2.0.so.0", "ld64.so.2"
      ]}
 ]


### PR DESCRIPTION
In order to make auditwheel work in PPC64le machines, the policy.json file
and the way it is read were changed.