### PR TITLE
Fix exception raised for certain symbols

### DIFF
--- a/auditwheel/policy/versioned_symbols.py
+++ b/auditwheel/policy/versioned_symbols.py
@@ -24,7 +24,9 @@ def versioned_symbols_policy(versioned_symbols: Dict[str, Set[str]]) -> int:
     required_vers = {}  # type: Dict[str, Set[str]]
     for symbols in versioned_symbols.values():
         for symbol in symbols:
-            sym_name, _ = symbol.split("_", 2)
+            if ".so" in symbol:
+                continue
+            sym_name, _ = symbol.split("_", 1)
             required_vers.setdefault(sym_name, set()).add(symbol)
     matching_policies = []  # type: List[int]
     for p in load_policies():

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -10,7 +10,21 @@ def test_policy():
 
 
 def test_policy_checks_glibc():
-    policy = versioned_symbols_policy({"some_library.so": {"GLIBC_2.5"}})
+    policy = versioned_symbols_policy(
+        {
+            "some_library.so": {
+                "GLIBC_2.5",
+                "OPENSSL_1.0.1_EC",
+                "some_library.so",
+            },
+        })
     assert policy > POLICY_PRIORITY_LOWEST
-    policy = versioned_symbols_policy({"some_library.so": {"GLIBC_999"}})
+    policy = versioned_symbols_policy(
+        {
+            "some_library.so": {
+                "GLIBC_999",
+                "OPENSSL_1.0.1_EC",
+                "some_library.so",
+            },
+        })
     assert policy == POLICY_PRIORITY_LOWEST


### PR DESCRIPTION
I was trying to repair wheels targeted for linux (not manylinux) on a more recent distro, and couldn’t get the cryptography library repaired, because it contained versioned symbols the current code could not handle:

```python
defaultdict(<function get_wheel_elfdata.<locals>.<lambda> at 0x7f90deb869d8>, {'libc.so.6': {'GLIBC_2.2.5', 'GLIBC_2.14', 'GLIBC_2.4'}, 'libcrypto.so.10': {'libcrypto.so.10', 'OPENSSL_1.0.1_EC', 'OPENSSL_1.0.1'}, 'libssl.so.10': {'libssl.so.10'}})
```

This change makes sure that these symbols can be successfully processed.