### PR TITLE
Process non-Python binaries (e.g. binary executables)

### DIFF
--- a/auditwheel/wheel_abi.py
+++ b/auditwheel/wheel_abi.py
@@ -41,19 +41,20 @@ def get_wheel_elfdata(wheel_fn: str):
                                     'The wheel has to be platlib compliant in order to be repaired by auditwheel.') %
                                    so_path_split[-1])
 
+            log.info('processing: %s', fn)
+            elftree = lddtree(fn)
+            full_elftree[fn] = elftree
             if is_py_ext:
-                log.info('processing: %s', fn)
-                elftree = lddtree(fn)
-                full_elftree[fn] = elftree
                 uses_PyFPE_jbuf |= elf_references_PyFPE_jbuf(elf)
-                for key, value in elf_find_versioned_symbols(elf):
-                    versioned_symbols[key].add(value)
+            for key, value in elf_find_versioned_symbols(elf):
+                versioned_symbols[key].add(value)
 
+            if is_py_ext:
                 if py_ver == 2:
                     uses_ucs2_symbols |= any(
                         True for _ in elf_find_ucs2_symbols(elf))
-                full_external_refs[fn] = lddtree_external_references(elftree,
-                                                                     ctx.path)
+            full_external_refs[fn] = lddtree_external_references(elftree,
+                                                                 ctx.path)
 
 
     log.debug(json.dumps(full_elftree, indent=4))

--- a/tests/testpackage/setup.py
+++ b/tests/testpackage/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+import subprocess
+
+cmd = 'gcc testpackage/testprogram.c -lgsl -o testpackage/testprogram'
+subprocess.check_call(cmd.split())
+
+setup(
+    name='testpackage',
+    packages=['testpackage'],
+    package_data={'testpackage': ['testprogram']}
+)

--- a/tests/testpackage/setup.py
+++ b/tests/testpackage/setup.py
@@ -6,6 +6,7 @@ subprocess.check_call(cmd.split())
 
 setup(
     name='testpackage',
+    version='0.0.1',
     packages=['testpackage'],
     package_data={'testpackage': ['testprogram']}
 )

--- a/tests/testpackage/testpackage/__init__.py
+++ b/tests/testpackage/testpackage/__init__.py
@@ -1,0 +1,8 @@
+import pkg_resources
+import subprocess
+
+
+def runit(x):
+    filename = pkg_resources.resource_filename(__name__, 'testprogram')
+    output = subprocess.check_output([filename, str(x)])
+    return float(x)

--- a/tests/testpackage/testpackage/testprogram.c
+++ b/tests/testpackage/testpackage/testprogram.c
@@ -1,0 +1,31 @@
+/* A simple example program to square a number using GSL. */
+
+#include <gsl/gsl_math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+    double x;
+    char *startptr, *endptr;
+
+    if (argc != 2)
+    {
+        fputs("Expected exactly one command line argument\n", stderr);
+        return EXIT_FAILURE;
+    }
+
+    startptr = argv[1];
+    endptr = NULL;
+    x = strtod(startptr, &endptr);
+
+    if (startptr == endptr)
+    {
+        fputs("Expected command line argument to be a float\n", stderr);
+        return EXIT_FAILURE;
+    }
+    
+    x = gsl_pow_2(x);
+    printf("%g\n", x);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This makes it possible to relocate and distribute executable binaries as well as Python extension binaries.

We would like to use this feature in the [LALSuite](https://pypi.org/project/lalsuite/) package. See https://git.ligo.org/lscsoft/lalsuite/merge_requests/164.