### PR TITLE
Remove "branches" stanza from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ services:
 notifications:
   email: false
 
-branches:
-  only:
-    - master
-
 before_install:
   - pip install --upgrade pip wheel
 


### PR DESCRIPTION
This is preventing automatic deployments to PyPI building on tags,
as the branches.only = [master] causes all tag builds to be ignored.

See note[*]: "Note that safelisting also prevents tagged commits from
being built."

[*]: https://docs.travis-ci.com/user/customizing-the-build#Safelisting-or-blocklisting-branches