### PR TITLE
WIP for #115 : PEP8 refactor, CI to be added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ target/
 *.zip
 wheelhoust-*
 tests/testpackage/testpackage/testprogram
+
+
+# IDE related
+.vscode/

--- a/auditwheel/__main__.py
+++ b/auditwheel/__main__.py
@@ -1,5 +1,5 @@
 import sys
 from .main import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/auditwheel/condatools.py
+++ b/auditwheel/condatools.py
@@ -29,6 +29,6 @@ class InCondaPkgCtx(InCondaPkg):
         return self
 
     def iter_files(self):
-        files = os.path.join(self.path, 'info', 'files')
+        files = os.path.join(self.path, "info", "files")
         with open(files) as f:
             return [native(l.strip()) for l in f.readlines()]

--- a/auditwheel/elfutils.py
+++ b/auditwheel/elfutils.py
@@ -7,16 +7,16 @@ from elftools.common.exceptions import ELFError  # type: ignore
 from typing import Iterator, Tuple, Optional, Dict, List
 
 
-def elf_read_dt_needed(fn : str) -> List[str]:
+def elf_read_dt_needed(fn: str) -> List[str]:
     needed = []
-    with open(fn, 'rb') as f:
+    with open(fn, "rb") as f:
         elf = ELFFile(f)
-        section = elf.get_section_by_name('.dynamic')
+        section = elf.get_section_by_name(".dynamic")
         if section is None:
-            raise ValueError('Could not find soname in %s' % fn)
+            raise ValueError("Could not find soname in %s" % fn)
 
         for t in section.iter_tags():
-            if t.entry.d_tag == 'DT_NEEDED':
+            if t.entry.d_tag == "DT_NEEDED":
                 needed.append(t.needed)
 
     return needed
@@ -28,11 +28,11 @@ def elf_file_filter(paths: Iterator[str]) -> Iterator[Tuple[str, ELFFile]]:
     """
 
     for path in paths:
-        if path.endswith('.py'):
+        if path.endswith(".py"):
             continue
         else:
             try:
-                with open(path, 'rb') as f:
+                with open(path, "rb") as f:
                     candidate = ELFFile(f)
                     yield path, candidate
             except ELFError:
@@ -41,58 +41,63 @@ def elf_file_filter(paths: Iterator[str]) -> Iterator[Tuple[str, ELFFile]]:
 
 
 def elf_find_versioned_symbols(elf: ELFFile) -> Iterator[Tuple[str, str]]:
-    section = elf.get_section_by_name('.gnu.version_r')
+    section = elf.get_section_by_name(".gnu.version_r")
 
     if section is not None:
         for verneed, verneed_iter in section.iter_versions():
-            if verneed.name.startswith('ld-linux'):
+            if verneed.name.startswith("ld-linux"):
                 continue
             for vernaux in verneed_iter:
-                yield (verneed.name,
-                       vernaux.name)
+                yield (verneed.name, vernaux.name)
 
 
 def elf_find_ucs2_symbols(elf: ELFFile) -> Iterator[str]:
-    section = elf.get_section_by_name('.dynsym')
+    section = elf.get_section_by_name(".dynsym")
     if section is not None:
         # look for UCS2 symbols that are externally referenced
         for sym in section.iter_symbols():
-            if ('PyUnicodeUCS2_' in sym.name and
-                    sym['st_shndx'] == 'SHN_UNDEF' and
-                    sym['st_info']['type'] == 'STT_FUNC'):
+            if (
+                "PyUnicodeUCS2_" in sym.name
+                and sym["st_shndx"] == "SHN_UNDEF"
+                and sym["st_info"]["type"] == "STT_FUNC"
+            ):
 
                 yield sym.name
 
 
 def elf_references_PyFPE_jbuf(elf: ELFFile) -> bool:
-    offending_symbol_names = ('PyFPE_jbuf', 'PyFPE_dummy', 'PyFPE_counter')
-    section = elf.get_section_by_name('.dynsym')
+    offending_symbol_names = ("PyFPE_jbuf", "PyFPE_dummy", "PyFPE_counter")
+    section = elf.get_section_by_name(".dynsym")
     if section is not None:
         # look for symbols that are externally referenced
         for sym in section.iter_symbols():
-            if (sym.name in offending_symbol_names and
-                    sym['st_shndx'] == 'SHN_UNDEF' and
-                    sym['st_info']['type'] in ('STT_FUNC', 'STT_NOTYPE')):
+            if (
+                sym.name in offending_symbol_names
+                and sym["st_shndx"] == "SHN_UNDEF"
+                and sym["st_info"]["type"] in ("STT_FUNC", "STT_NOTYPE")
+            ):
                 return True
     return False
 
 
 def elf_is_python_extension(fn, elf) -> Tuple[bool, Optional[int]]:
-    modname = basename(fn).split('.', 1)[0]
+    modname = basename(fn).split(".", 1)[0]
     module_init_f = {
-        'init' + modname: 2,
-        'PyInit_' + modname: 3,
-        '_cffi_pypyinit_' + modname: 2,
+        "init" + modname: 2,
+        "PyInit_" + modname: 3,
+        "_cffi_pypyinit_" + modname: 2,
     }
 
-    sect = elf.get_section_by_name('.dynsym')
+    sect = elf.get_section_by_name(".dynsym")
     if sect is None:
         return False, None
 
     for sym in sect.iter_symbols():
-        if (sym.name in module_init_f and
-                sym['st_shndx'] != 'SHN_UNDEF' and
-                sym['st_info']['type'] == 'STT_FUNC'):
+        if (
+            sym.name in module_init_f
+            and sym["st_shndx"] != "SHN_UNDEF"
+            and sym["st_info"]["type"] == "STT_FUNC"
+        ):
 
             return True, module_init_f[sym.name]
 
@@ -100,25 +105,19 @@ def elf_is_python_extension(fn, elf) -> Tuple[bool, Optional[int]]:
 
 
 def elf_read_rpaths(fn: str) -> Dict[str, List[str]]:
-    result = {'rpaths': [], 'runpaths': []}  # type: Dict[str, List[str]]
+    result = {"rpaths": [], "runpaths": []}  # type: Dict[str, List[str]]
 
-    with open(fn, 'rb') as f:
+    with open(fn, "rb") as f:
         elf = ELFFile(f)
-        section = elf.get_section_by_name('.dynamic')
+        section = elf.get_section_by_name(".dynamic")
         if section is None:
             return result
 
         for t in section.iter_tags():
-            if t.entry.d_tag == 'DT_RPATH':
-                result['rpaths'] = parse_ld_paths(
-                    t.rpath,
-                    root='/',
-                    path=fn)
-            elif t.entry.d_tag == 'DT_RUNPATH':
-                result['runpaths'] = parse_ld_paths(
-                    t.runpath,
-                    root='/',
-                    path=fn)
+            if t.entry.d_tag == "DT_RPATH":
+                result["rpaths"] = parse_ld_paths(t.rpath, root="/", path=fn)
+            elif t.entry.d_tag == "DT_RUNPATH":
+                result["runpaths"] = parse_ld_paths(t.runpath, root="/", path=fn)
 
     return result
 

--- a/auditwheel/genericpkgctx.py
+++ b/auditwheel/genericpkgctx.py
@@ -6,9 +6,9 @@ def InGenericPkgCtx(in_path, out_path=None):
     """Factory that returns a InWheelCtx or InCondaPkgCtx
     context manager depending on the file extension
     """
-    if in_path.endswith('.whl'):
+    if in_path.endswith(".whl"):
         return InWheelCtx(in_path, out_path)
-    if in_path.endswith('.tar.bz2'):
+    if in_path.endswith(".tar.bz2"):
         if out_path is not None:
             raise NotImplementedError()
         return InCondaPkgCtx(in_path)

--- a/auditwheel/hashfile.py
+++ b/auditwheel/hashfile.py
@@ -2,8 +2,8 @@ import hashlib
 
 
 def hashfile(afile, blocksize=65536):
-    """Hash the contents of an open file handle with SHA256"""    
-    hasher =  hashlib.sha256()
+    """Hash the contents of an open file handle with SHA256"""
+    hasher = hashlib.sha256()
     buf = afile.read(blocksize)
     while len(buf) > 0:
         hasher.update(buf)

--- a/auditwheel/main.py
+++ b/auditwheel/main.py
@@ -11,20 +11,25 @@ from . import main_repair
 
 
 def main():
-    dist = pkg_resources.get_distribution('auditwheel')
-    version = 'auditwheel %s installed at %s (python %s)' % (
-        dist.version, dist.location, sys.version[:3])
+    dist = pkg_resources.get_distribution("auditwheel")
+    version = "auditwheel %s installed at %s (python %s)" % (
+        dist.version,
+        dist.location,
+        sys.version[:3],
+    )
 
-    p = argparse.ArgumentParser(description='Cross-distro Python wheels.')
+    p = argparse.ArgumentParser(description="Cross-distro Python wheels.")
     p.set_defaults(prog=os.path.basename(sys.argv[0]))
-    p.add_argument('-V', '--version', action='version', version=version)
-    p.add_argument("-v",
-                   "--verbose",
-                   action='count',
-                   dest='verbose',
-                   default=0,
-                   help='Give more output. Option is additive')
-    sub_parsers = p.add_subparsers(metavar='command', dest='cmd')
+    p.add_argument("-V", "--version", action="version", version=version)
+    p.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        dest="verbose",
+        default=0,
+        help="Give more output. Option is additive",
+    )
+    sub_parsers = p.add_subparsers(metavar="command", dest="cmd")
 
     main_show.configure_parser(sub_parsers)
     main_addtag.configure_parser(sub_parsers)
@@ -41,13 +46,13 @@ def main():
     else:
         logging.basicConfig(level=logging.WARN)
 
-    if not hasattr(args, 'func'):
+    if not hasattr(args, "func"):
         p.print_help()
         return
 
     try:
         rval = args.func(args, p)
-    except:
+    except Exception:
         # TODO(rmcgibbo): nice message
         raise
 

--- a/auditwheel/main_addtag.py
+++ b/auditwheel/main_addtag.py
@@ -1,20 +1,19 @@
 from os.path import basename, exists, join, abspath
-from .policy import (load_policies, get_policy_name, get_priority_by_name,
-                     POLICY_PRIORITY_HIGHEST)
 
 
 def configure_parser(sub_parsers):
     help = "Add new platform ABI tags to a wheel"
 
-    p = sub_parsers.add_parser('addtag', help=help, description=help)
-    p.add_argument('WHEEL_FILE', help='Path to wheel file')
-    p.add_argument('-w',
-                   '--wheel-dir',
-                   dest='WHEEL_DIR',
-                   help=('Directory to store new wheel file (default:'
-                         ' "wheelhouse/")'),
-                   type=abspath,
-                   default='wheelhouse/')
+    p = sub_parsers.add_parser("addtag", help=help, description=help)
+    p.add_argument("WHEEL_FILE", help="Path to wheel file")
+    p.add_argument(
+        "-w",
+        "--wheel-dir",
+        dest="WHEEL_DIR",
+        help=("Directory to store new wheel file (default:" ' "wheelhouse/")'),
+        type=abspath,
+        default="wheelhouse/",
+    )
     p.set_defaults(func=execute)
 
 
@@ -28,14 +27,16 @@ def execute(args, p):
     wheel_abi = analyze_wheel_abi(args.WHEEL_FILE)
 
     parsed_fname = WHEEL_INFO_RE(basename(args.WHEEL_FILE))
-    in_fname_tags = parsed_fname.groupdict()['plat'].split('.')
+    in_fname_tags = parsed_fname.groupdict()["plat"].split(".")
 
-    print('%s recieves the following tag: "%s".' % (basename(args.WHEEL_FILE),
-                                                    wheel_abi.overall_tag))
-    print('Use ``auditwheel show`` for more details')
+    print(
+        '%s recieves the following tag: "%s".'
+        % (basename(args.WHEEL_FILE), wheel_abi.overall_tag)
+    )
+    print("Use ``auditwheel show`` for more details")
 
     if wheel_abi.overall_tag in in_fname_tags:
-        print('No tags to be added. Exiting.')
+        print("No tags to be added. Exiting.")
         return 1
 
     # todo: move more of this logic to separate file
@@ -46,12 +47,12 @@ def execute(args, p):
         try:
             out_wheel = add_platforms(ctx, [wheel_abi.overall_tag])
         except WheelToolsError as e:
-            print('\n%s.' % str(e), file=sys.stderr)
+            print("\n%s." % str(e), file=sys.stderr)
             return 1
 
         if out_wheel:
             # tell context manager to write wheel on exit with
             # the proper output directory
             ctx.out_wheel = join(args.WHEEL_DIR, basename(out_wheel))
-            print('\nUpdated wheel written to %s' % out_wheel)
+            print("\nUpdated wheel written to %s" % out_wheel)
     return 0

--- a/auditwheel/main_lddtree.py
+++ b/auditwheel/main_lddtree.py
@@ -1,7 +1,7 @@
 def configure_subparser(sub_parsers):
-    help = 'Analyze a single ELF file (similar to ``ldd``).'
-    p = sub_parsers.add_parser('lddtree', help=help, description=help)
-    p.add_argument('file', help='Path to .so file')
+    help = "Analyze a single ELF file (similar to ``ldd``)."
+    p = sub_parsers.add_parser("lddtree", help=help, description=help)
+    p.add_argument("file", help="Path to .so file")
     p.set_defaults(func=execute)
 
 

--- a/auditwheel/main_repair.py
+++ b/auditwheel/main_repair.py
@@ -1,39 +1,52 @@
 from os.path import isfile, exists, abspath, basename
-from .policy import (load_policies, get_policy_name, get_priority_by_name,
-                     POLICY_PRIORITY_HIGHEST)
+from .policy import (
+    load_policies,
+    get_policy_name,
+    get_priority_by_name,
+    POLICY_PRIORITY_HIGHEST,
+)
 
 
 def configure_parser(sub_parsers):
-    policy_names = [p['name'] for p in load_policies()]
+    policy_names = [p["name"] for p in load_policies()]
     highest_policy = get_policy_name(POLICY_PRIORITY_HIGHEST)
     help = "Vendor in external shared library dependencies of a wheel."
-    p = sub_parsers.add_parser('repair', help=help, description=help)
-    p.add_argument('WHEEL_FILE', help='Path to wheel file.')
+    p = sub_parsers.add_parser("repair", help=help, description=help)
+    p.add_argument("WHEEL_FILE", help="Path to wheel file.")
     p.add_argument(
-        '--plat',
-        dest='PLAT',
+        "--plat",
+        dest="PLAT",
         help='Desired target platform. (default: "%s")' % highest_policy,
         choices=policy_names,
-        default=highest_policy)
-    p.add_argument('-L',
-                   '--lib-sdir',
-                   dest='LIB_SDIR',
-                   help=('Subdirectory in packages to store copied libraries.'
-                         ' (default: ".libs")'),
-                   default='.libs')
-    p.add_argument('-w',
-                   '--wheel-dir',
-                   dest='WHEEL_DIR',
-                   type=abspath,
-                   help=('Directory to store delocated wheels (default:'
-                         ' "wheelhouse/")'),
-                   default='wheelhouse/')
-    p.add_argument('--no-update-tags',
-                   dest='UPDATE_TAGS',
-                   action='store_false',
-                   help=('Do not update the wheel filename tags and WHEEL info'
-                         ' to match the repaired platform tag.'),
-                   default=True)
+        default=highest_policy,
+    )
+    p.add_argument(
+        "-L",
+        "--lib-sdir",
+        dest="LIB_SDIR",
+        help=(
+            "Subdirectory in packages to store copied libraries." ' (default: ".libs")'
+        ),
+        default=".libs",
+    )
+    p.add_argument(
+        "-w",
+        "--wheel-dir",
+        dest="WHEEL_DIR",
+        type=abspath,
+        help=("Directory to store delocated wheels (default:" ' "wheelhouse/")'),
+        default="wheelhouse/",
+    )
+    p.add_argument(
+        "--no-update-tags",
+        dest="UPDATE_TAGS",
+        action="store_false",
+        help=(
+            "Do not update the wheel filename tags and WHEEL info"
+            " to match the repaired platform tag."
+        ),
+        default=True,
+    )
     p.set_defaults(func=execute)
 
 
@@ -44,11 +57,11 @@ def execute(args, p):
     from .wheel_abi import analyze_wheel_abi
 
     if not isfile(args.WHEEL_FILE):
-        p.error('cannot access %s. No such file' % args.WHEEL_FILE)
-    if find_executable('patchelf') is None:
-        p.error('cannot find the \'patchelf\' tool, which is required')
+        p.error("cannot access %s. No such file" % args.WHEEL_FILE)
+    if find_executable("patchelf") is None:
+        p.error("cannot find the 'patchelf' tool, which is required")
 
-    print('Repairing %s' % basename(args.WHEEL_FILE))
+    print("Repairing %s" % basename(args.WHEEL_FILE))
 
     if not exists(args.WHEEL_DIR):
         os.makedirs(args.WHEEL_DIR)
@@ -56,25 +69,30 @@ def execute(args, p):
     wheel_abi = analyze_wheel_abi(args.WHEEL_FILE)
     reqd_tag = get_priority_by_name(args.PLAT)
 
-    if (reqd_tag > get_priority_by_name(wheel_abi.sym_tag)):
-        msg = ('cannot repair "%s" to "%s" ABI because of the presence '
-               'of too-recent versioned symbols. You\'ll need to compile '
-               'the wheel on an older toolchain.' %
-               (args.WHEEL_FILE, args.PLAT))
+    if reqd_tag > get_priority_by_name(wheel_abi.sym_tag):
+        msg = (
+            'cannot repair "%s" to "%s" ABI because of the presence '
+            "of too-recent versioned symbols. You'll need to compile "
+            "the wheel on an older toolchain." % (args.WHEEL_FILE, args.PLAT)
+        )
         p.error(msg)
 
-    if (reqd_tag > get_priority_by_name(wheel_abi.ucs_tag)):
-        msg = ('cannot repair "%s" to "%s" ABI because it was compiled '
-               'against a UCS2 build of Python. You\'ll need to compile '
-               'the wheel against a wide-unicode build of Python.' %
-               (args.WHEEL_FILE, args.PLAT))
+    if reqd_tag > get_priority_by_name(wheel_abi.ucs_tag):
+        msg = (
+            'cannot repair "%s" to "%s" ABI because it was compiled '
+            "against a UCS2 build of Python. You'll need to compile "
+            "the wheel against a wide-unicode build of Python."
+            % (args.WHEEL_FILE, args.PLAT)
+        )
         p.error(msg)
 
-    out_wheel = repair_wheel(args.WHEEL_FILE,
-                             abi=args.PLAT,
-                             lib_sdir=args.LIB_SDIR,
-                             out_dir=args.WHEEL_DIR,
-                             update_tags=args.UPDATE_TAGS)
+    out_wheel = repair_wheel(
+        args.WHEEL_FILE,
+        abi=args.PLAT,
+        lib_sdir=args.LIB_SDIR,
+        out_dir=args.WHEEL_DIR,
+        update_tags=args.UPDATE_TAGS,
+    )
 
     if out_wheel is not None:
-        print('\nFixed-up wheel written to %s' % out_wheel)
+        print("\nFixed-up wheel written to %s" % out_wheel)

--- a/auditwheel/main_show.py
+++ b/auditwheel/main_show.py
@@ -1,79 +1,108 @@
 def configure_parser(sub_parsers):
     help = "Audit a wheel for external shared library dependencies."
-    p = sub_parsers.add_parser('show', help=help, description=help)
-    p.add_argument('WHEEL_FILE', help='Path to wheel file.')
+    p = sub_parsers.add_parser("show", help=help, description=help)
+    p.add_argument("WHEEL_FILE", help="Path to wheel file.")
     p.set_defaults(func=execute)
 
 
 def printp(text):
     from textwrap import wrap
+
     print()
-    print('\n'.join(wrap(text)))
+    print("\n".join(wrap(text)))
 
 
 def execute(args, p):
     import json
-    from functools import reduce
     from collections import OrderedDict
     from os.path import isfile, basename
-    from .policy import (load_policies, get_priority_by_name,
-                         POLICY_PRIORITY_LOWEST, POLICY_PRIORITY_HIGHEST,
-                         get_policy_name)
+    from .policy import (
+        load_policies,
+        get_priority_by_name,
+        POLICY_PRIORITY_LOWEST,
+        POLICY_PRIORITY_HIGHEST,
+        get_policy_name,
+    )
     from .wheel_abi import analyze_wheel_abi
+
     fn = basename(args.WHEEL_FILE)
 
     if not isfile(args.WHEEL_FILE):
-        p.error('cannot access %s. No such file' % args.WHEEL_FILE)
+        p.error("cannot access %s. No such file" % args.WHEEL_FILE)
 
     winfo = analyze_wheel_abi(args.WHEEL_FILE)
-    libs_with_versions = ['%s with versions %s' % (k, v)
-                          for k, v in winfo.versioned_symbols.items()]
+    libs_with_versions = [
+        "%s with versions %s" % (k, v) for k, v in winfo.versioned_symbols.items()
+    ]
 
-    printp('%s is consistent with the following platform tag: "%s".' %
-           (fn, winfo.overall_tag))
-
+    printp(
+        '%s is consistent with the following platform tag: "%s".'
+        % (fn, winfo.overall_tag)
+    )
+    pep513 = "https://www.python.org/dev/peps/pep-0513/#fpectl-builds-vs-no-fpectl-builds"
     if get_priority_by_name(winfo.pyfpe_tag) < POLICY_PRIORITY_HIGHEST:
-        printp(('This wheel uses the PyFPE_jbuf function, which is not '
-                'compatible with the manylinux1 tag. (see '
-                'https://www.python.org/dev/peps/pep-0513/#fpectl-builds-vs-no-fpectl-builds)'))
+        printp(
+            (
+                "This wheel uses the PyFPE_jbuf function, which is not "
+                "compatible with the manylinux1 tag. (see " + pep513 + ")"
+            )
+        )
         if args.verbose < 1:
             return
 
     if get_priority_by_name(winfo.ucs_tag) < POLICY_PRIORITY_HIGHEST:
-        printp(('This wheel is compiled against a narrow unicode (UCS2) '
-                'version of Python, which is not compatible with the '
-                'manylinux1 tag.'))
+        printp(
+            (
+                "This wheel is compiled against a narrow unicode (UCS2) "
+                "version of Python, which is not compatible with the "
+                "manylinux1 tag."
+            )
+        )
         if args.verbose < 1:
             return
 
     if len(libs_with_versions) == 0:
-        printp(("The wheel references no external versioned symbols from "
-                "system-provided shared libraries."))
+        printp(
+            (
+                "The wheel references no external versioned symbols from "
+                "system-provided shared libraries."
+            )
+        )
     else:
-        printp('The wheel references external versioned symbols in these '
-               'system-provided shared libraries: %s' %
-               ', '.join(libs_with_versions))
+        printp(
+            "The wheel references external versioned symbols in these "
+            "system-provided shared libraries: %s" % ", ".join(libs_with_versions)
+        )
 
     if get_priority_by_name(winfo.sym_tag) < POLICY_PRIORITY_HIGHEST:
-        printp(('This constrains the platform tag to "%s". '
-                'In order to achieve a more compatible tag, you would '
-                'need to recompile a new wheel from source on a system '
-                'with earlier versions of these libraries, such as '
-                'CentOS 5.') % winfo.sym_tag)
+        printp(
+            (
+                'This constrains the platform tag to "%s". '
+                "In order to achieve a more compatible tag, you would "
+                "need to recompile a new wheel from source on a system "
+                "with earlier versions of these libraries, such as "
+                "CentOS 5."
+            )
+            % winfo.sym_tag
+        )
         if args.verbose < 1:
             return
 
-    libs = winfo.external_refs[get_policy_name(POLICY_PRIORITY_LOWEST)]['libs']
+    libs = winfo.external_refs[get_policy_name(POLICY_PRIORITY_LOWEST)]["libs"]
     if len(libs) == 0:
-        printp('The wheel requires no external shared libraries! :)')
+        printp("The wheel requires no external shared libraries! :)")
     else:
-        printp(('The following external shared libraries are required '
-                'by the wheel:'))
+        printp(("The following external shared libraries are required " "by the wheel:"))
         print(json.dumps(OrderedDict(sorted(libs.items())), indent=4))
 
-    for p in sorted(load_policies(), key=lambda p: p['priority']):
-        if p['priority'] > get_priority_by_name(winfo.overall_tag):
-            printp(('In order to achieve the tag platform tag "%s" '
-                    'the following shared library dependencies '
-                    'will need to be eliminated:') % p['name'])
-            printp(', '.join(sorted(winfo.external_refs[p['name']]['libs'].keys())))
+    for p in sorted(load_policies(), key=lambda p: p["priority"]):
+        if p["priority"] > get_priority_by_name(winfo.overall_tag):
+            printp(
+                (
+                    'In order to achieve the tag platform tag "%s" '
+                    "the following shared library dependencies "
+                    "will need to be eliminated:"
+                )
+                % p["name"]
+            )
+            printp(", ".join(sorted(winfo.external_refs[p["name"]]["libs"].keys())))

--- a/auditwheel/policy/__init__.py
+++ b/auditwheel/policy/__init__.py
@@ -1,31 +1,37 @@
 import sys
 import json
 import platform as _platform_module
+
 from typing import Optional
 from os.path import join, dirname, abspath
 
-_sys_map = {'linux2': 'linux',
-            'linux': 'linux',
-            'darwin': 'osx',
-            'win32': 'win',
-            'openbsd5': 'openbsd'}
-non_x86_linux_machines = {'armv6l', 'armv7l', 'ppc64le'}
-platform = _sys_map.get(sys.platform, 'unknown')
+from .external_references import lddtree_external_references
+from .versioned_symbols import versioned_symbols_policy
+
+_sys_map = {
+    "linux2": "linux",
+    "linux": "linux",
+    "darwin": "osx",
+    "win32": "win",
+    "openbsd5": "openbsd",
+}
+non_x86_linux_machines = {"armv6l", "armv7l", "ppc64le"}
+platform = _sys_map.get(sys.platform, "unknown")
 linkage = _platform_module.architecture()[1]
 
 # https://docs.python.org/3/library/platform.html#platform.architecture
 bits = 8 * (8 if sys.maxsize > 2 ** 32 else 4)
 
 _PLATFORM_REPLACEMENT_MAP = {
-    'manylinux1_x86_64': ['linux_x86_64'],
-    'manylinux1_i686': ['linux_i686'],
+    "manylinux1_x86_64": ["linux_x86_64"],
+    "manylinux1_i686": ["linux_i686"],
 }
 
 # XXX: this could be weakened. The show command _could_ run on OS X or
 # Windows probably, but there's not much reason to inspect foreign package
 # that won't run on the platform.
-if platform != 'linux':
-    print('Error: This tool only supports Linux', file=sys.stderr)
+if platform != "linux":
+    print("Error: This tool only supports Linux", file=sys.stderr)
     sys.exit(1)
 
 # if linkage != 'ELF':
@@ -40,18 +46,19 @@ def get_arch_name():
     if _platform_module.machine() in non_x86_linux_machines:
         return _platform_module.machine()
     else:
-        return {64: 'x86_64', 32: 'i686'}[bits]
+        return {64: "x86_64", 32: "i686"}[bits]
+
 
 _ARCH_NAME = get_arch_name()
 
 
-with open(join(dirname(abspath(__file__)), 'policy.json')) as f:
+with open(join(dirname(abspath(__file__)), "policy.json")) as f:
     _POLICIES = json.load(f)
     for p in _POLICIES:
-        p['name'] = p['name'] + '_' + _ARCH_NAME
+        p["name"] = p["name"] + "_" + _ARCH_NAME
 
-POLICY_PRIORITY_HIGHEST = max(p['priority'] for p in _POLICIES)
-POLICY_PRIORITY_LOWEST = min(p['priority'] for p in _POLICIES)
+POLICY_PRIORITY_HIGHEST = max(p["priority"] for p in _POLICIES)
+POLICY_PRIORITY_LOWEST = min(p["priority"] for p in _POLICIES)
 
 
 def load_policies():
@@ -59,26 +66,26 @@ def load_policies():
 
 
 def _load_policy_schema():
-    with open(join(dirname(abspath(__file__)), 'policy-schema.json')) as f:
+    with open(join(dirname(abspath(__file__)), "policy-schema.json")) as f:
         schema = json.load(f)
     return schema
 
 
 def get_policy_name(priority: int) -> Optional[str]:
-    matches = [p['name'] for p in _POLICIES if p['priority'] == priority]
+    matches = [p["name"] for p in _POLICIES if p["priority"] == priority]
     if len(matches) == 0:
         return None
     if len(matches) > 1:
-        raise RuntimeError('Internal error. priorities should be unique')
+        raise RuntimeError("Internal error. priorities should be unique")
     return matches[0]
 
 
 def get_priority_by_name(name: str):
-    matches = [p['priority'] for p in _POLICIES if p['name'] == name]
+    matches = [p["priority"] for p in _POLICIES if p["name"] == name]
     if len(matches) == 0:
         return None
     if len(matches) > 1:
-        raise RuntimeError('Internal error. Policies should be unique.')
+        raise RuntimeError("Internal error. Policies should be unique.")
     return matches[0]
 
 
@@ -98,9 +105,10 @@ def get_replace_platforms(name: str):
     return _PLATFORM_REPLACEMENT_MAP.get(name, [])
 
 
-from .external_references import lddtree_external_references
-from .versioned_symbols import versioned_symbols_policy
-
-__all__ = ['lddtree_external_references', 'versioned_symbols_policy',
-           'load_policies', 'POLICY_PRIORITY_HIGHEST',
-           'POLICY_PRIORITY_LOWEST']
+__all__ = [
+    "lddtree_external_references",
+    "versioned_symbols_policy",
+    "load_policies",
+    "POLICY_PRIORITY_HIGHEST",
+    "POLICY_PRIORITY_LOWEST",
+]

--- a/auditwheel/policy/external_references.py
+++ b/auditwheel/policy/external_references.py
@@ -1,16 +1,13 @@
 import re
-import os
-import json
 import logging
-from typing import Tuple, Dict, List, Set, Any
 
-from elftools.elf.elffile import ELFFile  # type: ignore
+from typing import Dict, Set
 
 from ..elfutils import is_subdir
-from . import POLICY_PRIORITY_HIGHEST, load_policies
+from . import load_policies
 
 log = logging.getLogger(__name__)
-LIBPYTHON_RE = re.compile('^libpython\d\.\dm?.so(.\d)*$')
+LIBPYTHON_RE = re.compile(r"^libpython\d\.\dm?.so(.\d)*$")
 
 
 def lddtree_external_references(lddtree: Dict, wheel_path: str):
@@ -20,7 +17,7 @@ def lddtree_external_references(lddtree: Dict, wheel_path: str):
 
     def filter_libs(libs, whitelist):
         for lib in libs:
-            if 'ld-linux' in lib:
+            if "ld-linux" in lib:
                 # always exclude ld-linux.so
                 continue
             if LIBPYTHON_RE.match(lib):
@@ -38,7 +35,7 @@ def lddtree_external_references(lddtree: Dict, wheel_path: str):
         while libs:
             lib = libs.pop()
             reqs.add(lib)
-            for dep in filter_libs(lddtree['libs'][lib]['needed'], whitelist):
+            for dep in filter_libs(lddtree["libs"][lib]["needed"], whitelist):
                 if dep not in reqs:
                     libs.add(dep)
         return reqs
@@ -47,25 +44,25 @@ def lddtree_external_references(lddtree: Dict, wheel_path: str):
     for p in policies:
         needed_external_libs = []  # type: List[str]
 
-        if not (p['name'] == 'linux' and p['priority'] == 0):
+        if not (p["name"] == "linux" and p["priority"] == 0):
             # special-case the generic linux platform here, because it
             # doesn't have a whitelist. or, you could say its
             # whitelist is the complete set of all libraries. so nothing
             # is considered "external" that needs to be copied in.
-            whitelist = set(p['lib_whitelist'])
+            whitelist = set(p["lib_whitelist"])
             needed_external_libs = get_req_external(
-                set(filter_libs(lddtree['needed'], whitelist)),
-                whitelist)  # type: List[str]
+                set(filter_libs(lddtree["needed"], whitelist)), whitelist
+            )  # type: List[str]
 
         pol_ext_deps = {}
         for lib in needed_external_libs:
-            if is_subdir(lddtree['libs'][lib]['realpath'], wheel_path):
+            if is_subdir(lddtree["libs"][lib]["realpath"], wheel_path):
                 # we didn't filter libs that resolved via RPATH out
                 # earlier because we wanted to make sure to pick up
                 # our elf's indirect dependencies. But now we want to
                 # filter these ones out, since they're not "external".
-                log.debug('RPATH FTW: %s', lib)
+                log.debug("RPATH FTW: %s", lib)
                 continue
-            pol_ext_deps[lib] = lddtree['libs'][lib]['realpath']
-        ret[p['name']] = {'libs': pol_ext_deps, 'priority': p['priority']}
+            pol_ext_deps[lib] = lddtree["libs"][lib]["realpath"]
+        ret[p["name"]] = {"libs": pol_ext_deps, "priority": p["priority"]}
     return ret

--- a/auditwheel/policy/versioned_symbols.py
+++ b/auditwheel/policy/versioned_symbols.py
@@ -1,6 +1,6 @@
 import logging
-from functools import reduce
-from typing import Dict, Iterable, Set
+
+from typing import Dict, Set
 
 from . import load_policies
 
@@ -8,15 +8,18 @@ log = logging.getLogger(__name__)
 
 
 def versioned_symbols_policy(versioned_symbols: Dict[str, Set[str]]) -> int:
-    def policy_is_satisfied(policy_name: str,
-                            policy_sym_vers: Dict[str, Set[str]]):
+    def policy_is_satisfied(policy_name: str, policy_sym_vers: Dict[str, Set[str]]):
         policy_satisfied = True
-        for name in (set(required_vers) & set(policy_sym_vers)):
+        for name in set(required_vers) & set(policy_sym_vers):
             if not required_vers[name].issubset(policy_sym_vers[name]):
                 for symbol in required_vers[name] - policy_sym_vers[name]:
-                    log.debug('Package requires %s, incompatible with '
-                              'policy %s which requires %s', symbol,
-                              policy_name, policy_sym_vers[name])
+                    log.debug(
+                        "Package requires %s, incompatible with "
+                        "policy %s which requires %s",
+                        symbol,
+                        policy_name,
+                        policy_sym_vers[name],
+                    )
                 policy_satisfied = False
         return policy_satisfied
 
@@ -28,14 +31,14 @@ def versioned_symbols_policy(versioned_symbols: Dict[str, Set[str]]) -> int:
     matching_policies = []  # type: List[int]
     for p in load_policies():
         policy_sym_vers = {
-            sym_name: {sym_name + '_' + version for version in versions}
-            for sym_name, versions in p['symbol_versions'].items()
+            sym_name: {sym_name + "_" + version for version in versions}
+            for sym_name, versions in p["symbol_versions"].items()
         }
-        if policy_is_satisfied(p['name'], policy_sym_vers):
-            matching_policies.append(p['priority'])
+        if policy_is_satisfied(p["name"], policy_sym_vers):
+            matching_policies.append(p["priority"])
 
     if len(matching_policies) == 0:
         # the base policy (generic linux) should always match
-        raise RuntimeError('Internal error')
+        raise RuntimeError("Internal error")
 
     return max(matching_policies)

--- a/auditwheel/tmpdirs.py
+++ b/auditwheel/tmpdirs.py
@@ -1,5 +1,5 @@
-''' Contexts for *with* statement providing temporary directories
-'''
+""" Contexts for *with* statement providing temporary directories
+"""
 from __future__ import division, print_function, absolute_import
 import os
 import shutil
@@ -42,7 +42,7 @@ class TemporaryDirectory(object):
 
 
 class InTemporaryDirectory(TemporaryDirectory):
-    ''' Create, return, and change directory to a temporary directory
+    """ Create, return, and change directory to a temporary directory
 
     Examples
     --------
@@ -56,7 +56,7 @@ class InTemporaryDirectory(TemporaryDirectory):
     False
     >>> os.getcwd() == my_cwd
     True
-    '''
+    """
 
     def __enter__(self):
         self._pwd = os.getcwd()

--- a/auditwheel/tools.py
+++ b/auditwheel/tools.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 from glob import glob
-from os.path import exists, isfile, isdir
+from os.path import exists, isdir
 from os.path import join as pjoin
 import zipfile
 import subprocess
@@ -39,12 +39,12 @@ def zip2dir(zip_fname, out_dir):
     """
     # Use unzip command rather than zipfile module to preserve permissions
     # http://bugs.python.org/issue15795
-    subprocess.check_output(['unzip', '-o', '-d', out_dir, zip_fname])
+    subprocess.check_output(["unzip", "-o", "-d", out_dir, zip_fname])
 
     try:
         # but sometimes preserving permssions is really bad, and makes it
         # we don't have the permissions to read any of the files
-        with open(glob(pjoin(out_dir, '*.dist-info/RECORD'))[0]) as f:
+        with open(glob(pjoin(out_dir, "*.dist-info/RECORD"))[0]) as f:
             pass
     except PermissionError:
         shutil.rmtree(out_dir)
@@ -66,7 +66,7 @@ def dir2zip(in_dir, zip_fname):
     zip_fname : str
         Filename of zip archive to write
     """
-    z = zipfile.ZipFile(zip_fname, 'w', compression=zipfile.ZIP_DEFLATED)
+    z = zipfile.ZipFile(zip_fname, "w", compression=zipfile.ZIP_DEFLATED)
     for root, dirs, files in os.walk(in_dir):
         for file in files:
             fname = os.path.join(root, file)
@@ -78,7 +78,7 @@ def dir2zip(in_dir, zip_fname):
 def tarbz2todir(tarbz2_fname, out_dir):
     """Extract `tarbz2_fname` into output directory `out_dir`
     """
-    subprocess.check_output(['tar', 'xjf', tarbz2_fname, '-C', out_dir])
+    subprocess.check_output(["tar", "xjf", tarbz2_fname, "-C", out_dir])
 
 
 def find_package_dirs(root_path):
@@ -97,7 +97,7 @@ def find_package_dirs(root_path):
     """
     package_sdirs = set()
     for entry in os.listdir(root_path):
-        fname = entry if root_path == '.' else pjoin(root_path, entry)
-        if isdir(fname) and exists(pjoin(fname, '__init__.py')):
+        fname = entry if root_path == "." else pjoin(root_path, entry)
+        if isdir(fname) and exists(pjoin(fname, "__init__.py")):
             package_sdirs.add(fname)
     return package_sdirs

--- a/auditwheel/wheel_abi.py
+++ b/auditwheel/wheel_abi.py
@@ -4,23 +4,39 @@ import logging
 import functools
 import os
 from os.path import basename
-from typing import Dict, Set
-from collections import defaultdict, Mapping, Sequence, namedtuple
+from collections import defaultdict, Mapping, namedtuple
 
 from .genericpkgctx import InGenericPkgCtx
 from .lddtree import lddtree
-from .elfutils import (elf_file_filter, elf_find_versioned_symbols,
-                       elf_references_PyFPE_jbuf,
-                       elf_find_ucs2_symbols, elf_is_python_extension)
-from .policy import (lddtree_external_references, versioned_symbols_policy,
-                     get_policy_name, POLICY_PRIORITY_LOWEST,
-                     POLICY_PRIORITY_HIGHEST, load_policies)
+from .elfutils import (
+    elf_file_filter,
+    elf_find_versioned_symbols,
+    elf_references_PyFPE_jbuf,
+    elf_find_ucs2_symbols,
+    elf_is_python_extension,
+)
+from .policy import (
+    lddtree_external_references,
+    versioned_symbols_policy,
+    get_policy_name,
+    POLICY_PRIORITY_LOWEST,
+    POLICY_PRIORITY_HIGHEST,
+    load_policies,
+)
 
 log = logging.getLogger(__name__)
-WheelAbIInfo = namedtuple('WheelAbIInfo',
-                          ['overall_tag', 'external_refs', 'ref_tag',
-                           'versioned_symbols', 'sym_tag', 'ucs_tag',
-                           'pyfpe_tag'])
+WheelAbIInfo = namedtuple(
+    "WheelAbIInfo",
+    [
+        "overall_tag",
+        "external_refs",
+        "ref_tag",
+        "versioned_symbols",
+        "sym_tag",
+        "ucs_tag",
+        "pyfpe_tag",
+    ],
+)
 
 
 @functools.lru_cache()
@@ -36,18 +52,25 @@ def get_wheel_elfdata(wheel_fn: str):
         for fn, elf in elf_file_filter(ctx.iter_files()):
             is_py_ext, py_ver = elf_is_python_extension(fn, elf)
 
-            # Check for invalid binary wheel format: no shared library should be found in purelib
+            # Check for invalid binary wheel format: no shared library should be found in
+            #  purelib
             so_path_split = fn.split(os.sep)
-            if 'purelib' in so_path_split:
-                raise RuntimeError(('Invalid binary wheel, found shared library "%s" in purelib folder.\n'
-                                    'The wheel has to be platlib compliant in order to be repaired by auditwheel.') %
-                                   so_path_split[-1])
+            if "purelib" in so_path_split:
+                raise RuntimeError(
+                    (
+                        'Invalid binary wheel, found shared library "%s" in '
+                        "purelib folder.\n"
+                        "The wheel has to be platlib compliant in order to"
+                        "be repaired by auditwheel."
+                    )
+                    % so_path_split[-1]
+                )
 
-            log.info('processing: %s', fn)
+            log.info("processing: %s", fn)
             elftree = lddtree(fn)
 
             for key, value in elf_find_versioned_symbols(elf):
-                log.debug('key %s, value %s', key, value)
+                log.debug("key %s, value %s", key, value)
                 versioned_symbols[key].add(value)
 
             # If the ELF is a Python extention, we definitely need to include
@@ -56,10 +79,8 @@ def get_wheel_elfdata(wheel_fn: str):
                 full_elftree[fn] = elftree
                 uses_PyFPE_jbuf |= elf_references_PyFPE_jbuf(elf)
                 if py_ver == 2:
-                    uses_ucs2_symbols |= any(
-                        True for _ in elf_find_ucs2_symbols(elf))
-                full_external_refs[fn] = lddtree_external_references(elftree,
-                                                                     ctx.path)
+                    uses_ucs2_symbols |= any(True for _ in elf_find_ucs2_symbols(elf))
+                full_external_refs[fn] = lddtree_external_references(elftree, ctx.path)
             else:
                 # If the ELF is not a Python extension, it might be included in
                 # the wheel already because auditwheel repair vendored it, so
@@ -70,9 +91,8 @@ def get_wheel_elfdata(wheel_fn: str):
         # Get a list of all external libraries needed by ELFs in the wheel.
         needed_libs = {
             lib
-            for elf in itertools.chain(full_elftree.values(),
-                                       nonpy_elftree.values())
-            for lib in elf['needed']
+            for elf in itertools.chain(full_elftree.values(), nonpy_elftree.values())
+            for lib in elf["needed"]
         }
 
         for fn in nonpy_elftree.keys():
@@ -81,42 +101,46 @@ def get_wheel_elfdata(wheel_fn: str):
             # we should walk its elftree.
             if basename(fn) not in needed_libs:
                 full_elftree[fn] = nonpy_elftree[fn]
-                full_external_refs[fn] = lddtree_external_references(nonpy_elftree[fn],
-                                                                     ctx.path)
+                full_external_refs[fn] = lddtree_external_references(
+                    nonpy_elftree[fn], ctx.path
+                )
 
     log.debug(json.dumps(full_elftree, indent=4))
 
-    return (full_elftree, full_external_refs, versioned_symbols,
-            uses_ucs2_symbols, uses_PyFPE_jbuf)
+    return (
+        full_elftree,
+        full_external_refs,
+        versioned_symbols,
+        uses_ucs2_symbols,
+        uses_PyFPE_jbuf,
+    )
 
 
 def analyze_wheel_abi(wheel_fn: str):
     external_refs = {
-        p['name']: {'libs': {},
-                    'priority': p['priority']}
-        for p in load_policies()
+        p["name"]: {"libs": {}, "priority": p["priority"]} for p in load_policies()
     }
 
-    elftree_by_fn, external_refs_by_fn, versioned_symbols, has_ucs2, uses_PyFPE_jbuf= \
-            get_wheel_elfdata(wheel_fn)
+    elftree_by_fn, external_refs_by_fn, versioned_symbols, has_ucs2, uses_PyFPE_jbuf \
+        = get_wheel_elfdata(wheel_fn)
 
     for fn, elftree in elftree_by_fn.items():
         update(external_refs, external_refs_by_fn[fn])
 
     log.info(json.dumps(external_refs, indent=4))
-    log.debug('external reference info')
+    log.debug("external reference info")
     log.debug(json.dumps(external_refs, indent=4))
 
     symbol_policy = versioned_symbols_policy(versioned_symbols)
     ref_policy = max(
-        (e['priority'] for e in external_refs.values() if len(e['libs']) == 0),
-        default=POLICY_PRIORITY_LOWEST)
+        (e["priority"] for e in external_refs.values() if len(e["libs"]) == 0),
+        default=POLICY_PRIORITY_LOWEST,
+    )
 
     if has_ucs2:
         ucs_policy = POLICY_PRIORITY_LOWEST
     else:
         ucs_policy = POLICY_PRIORITY_HIGHEST
-
 
     if uses_PyFPE_jbuf:
         pyfpe_policy = POLICY_PRIORITY_LOWEST
@@ -127,10 +151,19 @@ def analyze_wheel_abi(wheel_fn: str):
     sym_tag = get_policy_name(symbol_policy)
     ucs_tag = get_policy_name(ucs_policy)
     pyfpe_tag = get_policy_name(pyfpe_policy)
-    overall_tag = get_policy_name(min(symbol_policy, ref_policy, ucs_policy, pyfpe_policy))
+    overall_tag = get_policy_name(
+        min(symbol_policy, ref_policy, ucs_policy, pyfpe_policy)
+    )
 
-    return WheelAbIInfo(overall_tag, external_refs, ref_tag, versioned_symbols,
-                        sym_tag, ucs_tag, pyfpe_tag)
+    return WheelAbIInfo(
+        overall_tag,
+        external_refs,
+        ref_tag,
+        versioned_symbols,
+        sym_tag,
+        ucs_tag,
+        pyfpe_tag,
+    )
 
 
 def update(d, u):
@@ -141,5 +174,5 @@ def update(d, u):
         elif isinstance(v, (str, int, float, type(None))):
             d[k] = u[k]
         else:
-            raise RuntimeError('!', d, k)
+            raise RuntimeError("!", d, k)
     return d

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ setuptools
 wheel == 0.31.1
 typing >=3.5.0.1
 pyelftools >=0.24
+pbr

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,3 +27,6 @@ packages = auditwheel
 [entry_points]
 console_scripts =
     auditwheel = auditwheel.main:main
+
+[flake8]
+max-line-length = 90

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,4 @@
 
 from setuptools import setup
 
-setup(
-    setup_requires=['pbr'],
-    pbr=True,
-)
+setup(setup_requires=["pbr"], pbr=True)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 pytest
 jsonschema
 numpy
-pypatchelf
+pbr

--- a/tests/quick_check_numpy.py
+++ b/tests/quick_check_numpy.py
@@ -7,6 +7,6 @@ X = rng.randn(500, 200)
 XTX = np.dot(X.T, X)
 U, S, VT = np.linalg.svd(XTX)
 if all(S > 0):
-    print('ok')
+    print("ok")
 else:
-    print('[ERROR] invalid singular values:', S)
+    print("[ERROR] invalid singular values:", S)

--- a/tests/test_bundled_cffi.py
+++ b/tests/test_bundled_cffi.py
@@ -2,7 +2,7 @@ from auditwheel.wheel_abi import analyze_wheel_abi
 
 
 def test_analyze_wheel_abi():
-    winfo = analyze_wheel_abi('tests/cffi-1.5.0-cp27-none-linux_x86_64.whl')
-    external_libs = winfo.external_refs['manylinux1_x86_64']['libs']
+    winfo = analyze_wheel_abi("tests/cffi-1.5.0-cp27-none-linux_x86_64.whl")
+    external_libs = winfo.external_refs["manylinux1_x86_64"]["libs"]
     assert len(external_libs) > 0
-    assert set(external_libs) == {'libffi.so.5'}
+    assert set(external_libs) == {"libffi.so.5"}

--- a/tests/test_bundled_pypy_snappy.py
+++ b/tests/test_bundled_pypy_snappy.py
@@ -2,8 +2,7 @@ from auditwheel.wheel_abi import analyze_wheel_abi
 
 
 def test_analyze_wheel_abi_pypy_cffi():
-    winfo = analyze_wheel_abi(
-        'tests/python_snappy-0.5.2-pp260-pypy_41-linux_x86_64.whl')
-    external_libs = winfo.external_refs['manylinux1_x86_64']['libs']
+    winfo = analyze_wheel_abi("tests/python_snappy-0.5.2-pp260-pypy_41-linux_x86_64.whl")
+    external_libs = winfo.external_refs["manylinux1_x86_64"]["libs"]
     assert len(external_libs) > 0
-    assert set(external_libs) == {'libsnappy.so.1'}
+    assert set(external_libs) == {"libsnappy.so.1"}

--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -8,21 +8,23 @@ import warnings
 from distutils.spawn import find_executable
 
 VERBOSE = True
-ENCODING = 'utf-8'
-MANYLINUX_IMAGE_ID = 'quay.io/pypa/manylinux1_x86_64'
-DOCKER_CONTAINER_NAME = 'auditwheel-test-manylinux'
-PYTHON_IMAGE_ID = 'python:3.5'
-PATH = ('/opt/python/cp35-cp35m/bin:/opt/rh/devtoolset-2/root/usr/bin:'
-        '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin')
-WHEEL_CACHE_FOLDER = op.expanduser('~/.cache/auditwheel_tests')
-ORIGINAL_NUMPY_WHEEL = 'numpy-1.11.0-cp35-cp35m-linux_x86_64.whl'
-ORIGINAL_SIX_WHEEL = 'six-1.11.0-py2.py3-none-any.whl'
+ENCODING = "utf-8"
+MANYLINUX_IMAGE_ID = "quay.io/pypa/manylinux1_x86_64"
+DOCKER_CONTAINER_NAME = "auditwheel-test-manylinux"
+PYTHON_IMAGE_ID = "python:3.5"
+PATH = (
+    "/opt/python/cp35-cp35m/bin:/opt/rh/devtoolset-2/root/usr/bin:"
+    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+)
+WHEEL_CACHE_FOLDER = op.expanduser("~/.cache/auditwheel_tests")
+ORIGINAL_NUMPY_WHEEL = "numpy-1.11.0-cp35-cp35m-linux_x86_64.whl"
+ORIGINAL_SIX_WHEEL = "six-1.11.0-py2.py3-none-any.whl"
 
 
 def find_src_folder():
-    candidate = op.abspath(op.join(op.dirname(__file__), '..'))
+    candidate = op.abspath(op.join(op.dirname(__file__), ".."))
     contents = os.listdir(candidate)
-    if 'setup.py' in contents and 'auditwheel' in contents:
+    if "setup.py" in contents and "auditwheel" in contents:
         return candidate
 
 
@@ -32,18 +34,18 @@ def docker_start(image, volumes={}, env_variables={}):
     Return the container id to be used for 'docker exec' commands.
     """
     # Make sure to use the latest public version of the docker image
-    cmd = ['docker', 'pull', image]
+    cmd = ["docker", "pull", image]
     if VERBOSE:
         print("$ " + " ".join(cmd))
     output = check_output(cmd).decode(ENCODING).strip()
     if VERBOSE:
         print(output)
-    cmd = ['docker', 'run', '-d']
+    cmd = ["docker", "run", "-d"]
     for guest_path, host_path in sorted(volumes.items()):
-        cmd.extend(['-v', '%s:%s' % (host_path, guest_path)])
+        cmd.extend(["-v", "%s:%s" % (host_path, guest_path)])
     for name, value in sorted(env_variables.items()):
-        cmd.extend(['-e', '%s=%s' % (name, value)])
-    cmd.extend([image, 'sleep', '10000'])
+        cmd.extend(["-e", "%s=%s" % (name, value)])
+    cmd.extend([image, "sleep", "10000"])
     if VERBOSE:
         print("$ " + " ".join(cmd))
     return check_output(cmd).decode(ENCODING).strip()
@@ -53,7 +55,7 @@ def docker_exec(container_id, cmd):
     """Executed a command in the runtime context of a running container."""
     if isinstance(cmd, str):
         cmd = cmd.split()
-    cmd = ['docker', 'exec', container_id] + cmd
+    cmd = ["docker", "exec", container_id] + cmd
     if VERBOSE:
         print("$ " + " ".join(cmd))
     output = check_output(cmd).decode(ENCODING)
@@ -65,14 +67,13 @@ def docker_exec(container_id, cmd):
 @pytest.yield_fixture
 def docker_container():
     if find_executable("docker") is None:
-        pytest.skip('docker is required')
+        pytest.skip("docker is required")
     if not op.exists(WHEEL_CACHE_FOLDER):
         os.makedirs(WHEEL_CACHE_FOLDER)
     src_folder = find_src_folder()
     if src_folder is None:
-        pytest.skip('Can only be run from the source folder')
-    io_folder = tempfile.mkdtemp(prefix='tmp_auditwheel_test_manylinux_',
-                                 dir=src_folder)
+        pytest.skip("Can only be run from the source folder")
+    io_folder = tempfile.mkdtemp(prefix="tmp_auditwheel_test_manylinux_", dir=src_folder)
     manylinux_id, python_id = None, None
     try:
         # Launch a docker container with volumes and pre-configured Python
@@ -82,28 +83,30 @@ def docker_container():
         # wheels
         manylinux_id = docker_start(
             MANYLINUX_IMAGE_ID,
-            volumes={'/io': io_folder, '/auditwheel_src': src_folder},
-            env_variables={'PATH': PATH})
+            volumes={"/io": io_folder, "/auditwheel_src": src_folder},
+            env_variables={"PATH": PATH},
+        )
         # Install the development version of auditwheel from source:
-        docker_exec(manylinux_id, 'pip install -U pip setuptools')
-        docker_exec(manylinux_id, 'pip install -U /auditwheel_src')
+        docker_exec(manylinux_id, "pip install -U pip setuptools")
+        docker_exec(manylinux_id, "pip install -U /auditwheel_src")
 
         # Launch a docker container with a more recent userland to check that
         # the generated wheel can install and run correctly.
         python_id = docker_start(
-            PYTHON_IMAGE_ID,
-            volumes={'/io': io_folder, '/auditwheel_src': src_folder})
-        docker_exec(python_id, 'pip install -U pip')
+            PYTHON_IMAGE_ID, volumes={"/io": io_folder, "/auditwheel_src": src_folder}
+        )
+        docker_exec(python_id, "pip install -U pip")
         yield manylinux_id, python_id, io_folder
     finally:
         for container_id in [manylinux_id, python_id]:
             if container_id is None:
                 continue
             try:
-                check_call(['docker', 'rm', '-f', container_id])
+                check_call(["docker", "rm", "-f", container_id])
             except CalledProcessError:
-                warnings.warn('failed to terminate and delete container %s'
-                              % container_id)
+                warnings.warn(
+                    "failed to terminate and delete container %s" % container_id
+                )
         shutil.rmtree(io_folder)
 
 
@@ -113,51 +116,56 @@ def test_build_repair_numpy(docker_container):
     # First build numpy from source as a naive linux wheel that is tied
     # to system libraries (atlas, libgfortran...)
     manylinux_id, python_id, io_folder = docker_container
-    docker_exec(manylinux_id, 'yum install -y atlas atlas-devel')
+    docker_exec(manylinux_id, "yum install -y atlas atlas-devel")
 
     if op.exists(op.join(WHEEL_CACHE_FOLDER, ORIGINAL_NUMPY_WHEEL)):
         # If numpy has already been built and put in cache, let's reuse this.
-        shutil.copy2(op.join(WHEEL_CACHE_FOLDER, ORIGINAL_NUMPY_WHEEL),
-                     op.join(io_folder, ORIGINAL_NUMPY_WHEEL))
+        shutil.copy2(
+            op.join(WHEEL_CACHE_FOLDER, ORIGINAL_NUMPY_WHEEL),
+            op.join(io_folder, ORIGINAL_NUMPY_WHEEL),
+        )
     else:
         # otherwise build the original linux_x86_64 numpy wheel from source
         # and put the result in the cache folder to speed-up future build.
         # This part of the build is independent of the auditwheel code-base
         # so it's safe to put it in cache.
-        docker_exec(manylinux_id,
-                    'pip wheel -w /io --no-binary=:all: numpy==1.11.0')
-        shutil.copy2(op.join(io_folder, ORIGINAL_NUMPY_WHEEL),
-                     op.join(WHEEL_CACHE_FOLDER, ORIGINAL_NUMPY_WHEEL))
+        docker_exec(manylinux_id, "pip wheel -w /io --no-binary=:all: numpy==1.11.0")
+        shutil.copy2(
+            op.join(io_folder, ORIGINAL_NUMPY_WHEEL),
+            op.join(WHEEL_CACHE_FOLDER, ORIGINAL_NUMPY_WHEEL),
+        )
     filenames = os.listdir(io_folder)
     assert filenames == [ORIGINAL_NUMPY_WHEEL]
     orig_wheel = filenames[0]
-    assert 'manylinux' not in orig_wheel
+    assert "manylinux" not in orig_wheel
 
     # Repair the wheel using the manylinux1 container
-    docker_exec(manylinux_id, 'auditwheel repair -w /io /io/' + orig_wheel)
+    docker_exec(manylinux_id, "auditwheel repair -w /io /io/" + orig_wheel)
     filenames = os.listdir(io_folder)
     assert len(filenames) == 2
-    repaired_wheels = [fn for fn in filenames if 'manylinux1' in fn]
-    assert repaired_wheels == ['numpy-1.11.0-cp35-cp35m-manylinux1_x86_64.whl']
+    repaired_wheels = [fn for fn in filenames if "manylinux1" in fn]
+    assert repaired_wheels == ["numpy-1.11.0-cp35-cp35m-manylinux1_x86_64.whl"]
     repaired_wheel = repaired_wheels[0]
-    output = docker_exec(manylinux_id, 'auditwheel show /io/' + repaired_wheel)
+    output = docker_exec(manylinux_id, "auditwheel show /io/" + repaired_wheel)
     assert (
-        'numpy-1.11.0-cp35-cp35m-manylinux1_x86_64.whl is consistent'
+        "numpy-1.11.0-cp35-cp35m-manylinux1_x86_64.whl is consistent"
         ' with the following platform tag: "manylinux1_x86_64"'
-    ) in output.replace('\n', ' ')
+    ) in output.replace("\n", " ")
 
     # Check that the repaired numpy wheel can be installed and executed
     # on a modern linux image.
-    docker_exec(python_id, 'pip install /io/' + repaired_wheel)
+    docker_exec(python_id, "pip install /io/" + repaired_wheel)
     output = docker_exec(
-        python_id, 'python /auditwheel_src/tests/quick_check_numpy.py').strip()
-    assert output.strip() == 'ok'
+        python_id, "python /auditwheel_src/tests/quick_check_numpy.py"
+    ).strip()
+    assert output.strip() == "ok"
 
     # Check that numpy f2py works with a more recent version of gfortran
-    docker_exec(python_id, 'apt-get update -yqq')
-    docker_exec(python_id, 'apt-get install -y gfortran')
-    docker_exec(python_id, 'python -m numpy.f2py'
-                           '       -c /auditwheel_src/tests/foo.f90 -m foo')
+    docker_exec(python_id, "apt-get update -yqq")
+    docker_exec(python_id, "apt-get install -y gfortran")
+    docker_exec(
+        python_id, "python -m numpy.f2py" "       -c /auditwheel_src/tests/foo.f90 -m foo"
+    )
 
     # Check that the 2 fortran runtimes are well isolated and can be loaded
     # at once in the same Python program:
@@ -168,34 +176,42 @@ def test_build_wheel_with_binary_executable(docker_container):
     # Test building a wheel that contains a binary executable (e.g., a program)
 
     manylinux_id, python_id, io_folder = docker_container
-    docker_exec(manylinux_id, 'yum install -y gsl-devel')
+    docker_exec(manylinux_id, "yum install -y gsl-devel")
 
-    docker_exec(manylinux_id, ['bash', '-c', 'cd /auditwheel_src/tests/testpackage && python setup.py bdist_wheel -d /io'])
+    docker_exec(
+        manylinux_id,
+        [
+            "bash",
+            "-c",
+            "cd /auditwheel_src/tests/testpackage && python setup.py bdist_wheel -d /io",
+        ],
+    )
 
     filenames = os.listdir(io_folder)
-    assert filenames == ['testpackage-0.0.1-py3-none-any.whl']
+    assert filenames == ["testpackage-0.0.1-py3-none-any.whl"]
     orig_wheel = filenames[0]
-    assert 'manylinux' not in orig_wheel
+    assert "manylinux" not in orig_wheel
 
     # Repair the wheel using the manylinux1 container
-    docker_exec(manylinux_id, 'auditwheel repair -w /io /io/' + orig_wheel)
+    docker_exec(manylinux_id, "auditwheel repair -w /io /io/" + orig_wheel)
     filenames = os.listdir(io_folder)
     assert len(filenames) == 2
-    repaired_wheels = [fn for fn in filenames if 'manylinux1' in fn]
-    assert repaired_wheels == ['testpackage-0.0.1-py3-none-manylinux1_x86_64.whl']
+    repaired_wheels = [fn for fn in filenames if "manylinux1" in fn]
+    assert repaired_wheels == ["testpackage-0.0.1-py3-none-manylinux1_x86_64.whl"]
     repaired_wheel = repaired_wheels[0]
-    output = docker_exec(manylinux_id, 'auditwheel show /io/' + repaired_wheel)
+    output = docker_exec(manylinux_id, "auditwheel show /io/" + repaired_wheel)
     assert (
-        'testpackage-0.0.1-py3-none-manylinux1_x86_64.whl is consistent'
+        "testpackage-0.0.1-py3-none-manylinux1_x86_64.whl is consistent"
         ' with the following platform tag: "manylinux1_x86_64"'
-    ) in output.replace('\n', ' ')
+    ) in output.replace("\n", " ")
 
     # Check that the repaired numpy wheel can be installed and executed
     # on a modern linux image.
-    docker_exec(python_id, 'pip install /io/' + repaired_wheel)
+    docker_exec(python_id, "pip install /io/" + repaired_wheel)
     output = docker_exec(
-        python_id, ['python', '-c', 'from testpackage import runit; print(runit(1.5))']).strip()
-    assert output.strip() == '2.25'
+        python_id, ["python", "-c", "from testpackage import runit; print(runit(1.5))"]
+    ).strip()
+    assert output.strip() == "2.25"
 
 
 def test_build_repair_pure_wheel(docker_container):
@@ -203,31 +219,36 @@ def test_build_repair_pure_wheel(docker_container):
 
     if op.exists(op.join(WHEEL_CACHE_FOLDER, ORIGINAL_SIX_WHEEL)):
         # If six has already been built and put in cache, let's reuse this.
-        shutil.copy2(op.join(WHEEL_CACHE_FOLDER, ORIGINAL_SIX_WHEEL),
-                     op.join(io_folder, ORIGINAL_SIX_WHEEL))
+        shutil.copy2(
+            op.join(WHEEL_CACHE_FOLDER, ORIGINAL_SIX_WHEEL),
+            op.join(io_folder, ORIGINAL_SIX_WHEEL),
+        )
     else:
-        docker_exec(manylinux_id,
-                    'pip wheel -w /io --no-binary=:all: six==1.11.0')
-        shutil.copy2(op.join(io_folder, ORIGINAL_SIX_WHEEL),
-                     op.join(WHEEL_CACHE_FOLDER, ORIGINAL_SIX_WHEEL))
+        docker_exec(manylinux_id, "pip wheel -w /io --no-binary=:all: six==1.11.0")
+        shutil.copy2(
+            op.join(io_folder, ORIGINAL_SIX_WHEEL),
+            op.join(WHEEL_CACHE_FOLDER, ORIGINAL_SIX_WHEEL),
+        )
 
     filenames = os.listdir(io_folder)
     assert filenames == [ORIGINAL_SIX_WHEEL]
     orig_wheel = filenames[0]
-    assert 'manylinux' not in orig_wheel
+    assert "manylinux" not in orig_wheel
 
     # Repair the wheel using the manylinux1 container
-    docker_exec(manylinux_id, 'auditwheel repair -w /io /io/' + orig_wheel)
+    docker_exec(manylinux_id, "auditwheel repair -w /io /io/" + orig_wheel)
     filenames = os.listdir(io_folder)
     assert len(filenames) == 1  # no new wheels
     assert filenames == [ORIGINAL_SIX_WHEEL]
 
-    output = docker_exec(manylinux_id, 'auditwheel show /io/' + filenames[0])
-    assert ''.join([
-        ORIGINAL_SIX_WHEEL,
-        ' is consistent with the following platform tag: ',
-        '"manylinux1_x86_64".  ',
-        'The wheel references no external versioned symbols from system- ',
-        'provided shared libraries.  ',
-        'The wheel requires no external shared libraries! :)',
-    ]) in output.replace('\n', ' ')
+    output = docker_exec(manylinux_id, "auditwheel show /io/" + filenames[0])
+    assert "".join(
+        [
+            ORIGINAL_SIX_WHEEL,
+            " is consistent with the following platform tag: ",
+            '"manylinux1_x86_64".  ',
+            "The wheel references no external versioned symbols from system- ",
+            "provided shared libraries.  ",
+            "The wheel requires no external shared libraries! :)",
+        ]
+    ) in output.replace("\n", " ")

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,8 +1,11 @@
 from jsonschema import validate
-from auditwheel.policy import (load_policies, _load_policy_schema,
-                               versioned_symbols_policy,
-                               POLICY_PRIORITY_HIGHEST,
-                               POLICY_PRIORITY_LOWEST)
+from auditwheel.policy import (
+    load_policies,
+    _load_policy_schema,
+    versioned_symbols_policy,
+    POLICY_PRIORITY_HIGHEST,
+    POLICY_PRIORITY_LOWEST,
+)
 
 
 def test_policy():

--- a/tests/test_pyfpe.py
+++ b/tests/test_pyfpe.py
@@ -1,8 +1,11 @@
 from auditwheel.wheel_abi import analyze_wheel_abi
-from auditwheel.policy import POLICY_PRIORITY_LOWEST
 
 
 def test_analyze_wheel_abi():
-    winfo = analyze_wheel_abi('tests/fpewheel-0.0.0-cp35-cp35m-linux_x86_64.whl')
-    assert winfo.sym_tag == 'manylinux1_x86_64'  # for external symbols, it could get manylinux1
-    assert winfo.pyfpe_tag == 'linux_x86_64'     # but for having the pyfpe reference, it gets just linux
+    winfo = analyze_wheel_abi("tests/fpewheel-0.0.0-cp35-cp35m-linux_x86_64.whl")
+    assert (
+        winfo.sym_tag == "manylinux1_x86_64"
+    )  # for external symbols, it could get manylinux1
+    assert (
+        winfo.pyfpe_tag == "linux_x86_64"
+    )  # but for having the pyfpe reference, it gets just linux

--- a/tests/testpackage/setup.py
+++ b/tests/testpackage/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup
 import subprocess
 
-cmd = 'gcc testpackage/testprogram.c -lgsl -lgslcblas -o testpackage/testprogram'
+cmd = "gcc testpackage/testprogram.c -lgsl -lgslcblas -o testpackage/testprogram"
 subprocess.check_call(cmd.split())
 
 setup(
-    name='testpackage',
-    version='0.0.1',
-    packages=['testpackage'],
-    package_data={'testpackage': ['testprogram']}
+    name="testpackage",
+    version="0.0.1",
+    packages=["testpackage"],
+    package_data={"testpackage": ["testprogram"]},
 )

--- a/tests/testpackage/testpackage/__init__.py
+++ b/tests/testpackage/testpackage/__init__.py
@@ -3,6 +3,6 @@ import subprocess
 
 
 def runit(x):
-    filename = pkg_resources.resource_filename(__name__, 'testprogram')
+    filename = pkg_resources.resource_filename(__name__, "testprogram")
     output = subprocess.check_output([filename, str(x)])
     return float(output)


### PR DESCRIPTION
In addition to the pep8 formatting from flake8 errors/warnings,

certain mentions : 

1. added an entry to .gitignore for vscode
2. One file needed a more logical change
auditwheel/tools.py on Line No. 47
`with open(glob(pjoin(out_dir, '*.dist-info/RECORD'))[0]) as f:`
The f is not needed.

Git message,
Reformatted python source as per PEP8

Modified all files referencing to pep8 guidelines

Used flake8 for audit.

Used black to format some files

The CI part using tox/travis is yet to be done
    and will be taken ahead by maintainers.