### PR TITLE
Show all shared libraries found in purelib

### DIFF
--- a/auditwheel/wheel_abi.py
+++ b/auditwheel/wheel_abi.py
@@ -52,7 +52,7 @@ def get_wheel_elfdata(wheel_fn: str):
             if 'purelib' in so_path_split:
                 shared_libraries_in_purelib.append(so_path_split[-1])
 
-            # If at least one shared library exists in purlib, this is going to
+            # If at least one shared library exists in purelib, this is going to
             # fail and there's no need to do further checks
             if not shared_libraries_in_purelib:
                 log.debug('processing: %s', fn)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ jsonschema
 numpy
 pypatchelf
 flake8
+pretend

--- a/tests/unit/test_wheel_abi.py
+++ b/tests/unit/test_wheel_abi.py
@@ -12,16 +12,12 @@ class TestGetWheelElfdata:
             (
                 # A single invalid file
                 [os.sep.join(["purelib", "foo"])],
-                'Invalid binary wheel, found shared library "foo" in purelib '
-                "folder.\nThe wheel has to be platlib compliant in order to be "
-                "repaired by auditwheel.",
+                "Invalid binary wheel, found the following shared library/libraries in purelib folder:\n\tfoo\nThe wheel has to be platlib compliant in order to be repaired by auditwheel.",
             ),
             (
-                # Multiple invalid files, does not include 'bar' in message
+                # Multiple invalid files
                 [os.sep.join(["purelib", "foo"]), os.sep.join(["purelib", "bar"])],
-                'Invalid binary wheel, found shared library "foo" in purelib '
-                "folder.\nThe wheel has to be platlib compliant in order to be "
-                "repaired by auditwheel.",
+                "Invalid binary wheel, found the following shared library/libraries in purelib folder:\n\tfoo\n\tbar\nThe wheel has to be platlib compliant in order to be repaired by auditwheel.",
             ),
         ],
     )

--- a/tests/unit/test_wheel_abi.py
+++ b/tests/unit/test_wheel_abi.py
@@ -1,0 +1,48 @@
+import os
+
+import pytest
+import pretend
+from auditwheel import wheel_abi
+
+
+class TestGetWheelElfdata:
+    @pytest.mark.parametrize(
+        "filenames, message",
+        [
+            (
+                # A single invalid file
+                [os.sep.join(["purelib", "foo"])],
+                'Invalid binary wheel, found shared library "foo" in purelib '
+                "folder.\nThe wheel has to be platlib compliant in order to be "
+                "repaired by auditwheel.",
+            ),
+            (
+                # Multiple invalid files, does not include 'bar' in message
+                [os.sep.join(["purelib", "foo"]), os.sep.join(["purelib", "bar"])],
+                'Invalid binary wheel, found shared library "foo" in purelib '
+                "folder.\nThe wheel has to be platlib compliant in order to be "
+                "repaired by auditwheel.",
+            ),
+        ],
+    )
+    def test_finds_shared_library_in_purelib(self, filenames, message, monkeypatch):
+        entered_context = pretend.stub(iter_files=lambda: filenames)
+        context = pretend.stub(
+            __enter__=lambda: entered_context, __exit__=lambda *a: None
+        )
+        InGenericPkgCtx = pretend.stub(__call__=lambda a: context)
+
+        monkeypatch.setattr(wheel_abi, "InGenericPkgCtx", InGenericPkgCtx)
+        monkeypatch.setattr(
+            wheel_abi, "elf_is_python_extension", lambda fn, elf: (fn, elf)
+        )
+        monkeypatch.setattr(
+            wheel_abi,
+            "elf_file_filter",
+            lambda fns: [(fn, pretend.stub()) for fn in fns],
+        )
+
+        with pytest.raises(RuntimeError) as exec_info:
+            wheel_abi.get_wheel_elfdata("/fakepath")
+
+        assert exec_info.value.args == (message,)


### PR DESCRIPTION
Instead of just outputting the first shared library found in `purelib`, include a list of all offending files.