### PR TITLE
Check compatibility after repairing wheel

### DIFF
--- a/auditwheel/main_repair.py
+++ b/auditwheel/main_repair.py
@@ -96,7 +96,7 @@ def execute(args, p):
             msg = ('Produced a wheel %r, but it is no longer compatible '
                    'with the %s tag, possibly because grafted libraries '
                    'require more recent symbols.' %
-                   (out_wheel, reqd_tag))
+                   (out_wheel, args.PLAT))
             sys.exit(msg)
 
         logger.info('\nFixed-up wheel written to %s', out_wheel)

--- a/auditwheel/main_repair.py
+++ b/auditwheel/main_repair.py
@@ -2,6 +2,7 @@ from os.path import isfile, exists, abspath, basename
 from .policy import (load_policies, get_policy_name, get_priority_by_name,
                      POLICY_PRIORITY_HIGHEST)
 import logging
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -90,5 +91,12 @@ def execute(args, p):
                                      lib_sdir=args.LIB_SDIR,
                                      out_dir=args.WHEEL_DIR,
                                      update_tags=args.UPDATE_TAGS)
+
+        elif reqd_tag < get_priority_by_name(analyzed_tag):
+            msg = ('Produced a wheel %r, but it is no longer compatible '
+                   'with the %s tag, possibly because grafted libraries '
+                   'require more recent symbols.' %
+                   (out_wheel, reqd_tag))
+            sys.exit(msg)
 
         logger.info('\nFixed-up wheel written to %s', out_wheel)

--- a/auditwheel/main_repair.py
+++ b/auditwheel/main_repair.py
@@ -92,7 +92,7 @@ def execute(args, p):
                                      out_dir=args.WHEEL_DIR,
                                      update_tags=args.UPDATE_TAGS)
 
-        elif reqd_tag < get_priority_by_name(analyzed_tag):
+        elif reqd_tag > get_priority_by_name(analyzed_tag):
             msg = ('Produced a wheel %r, but it is no longer compatible '
                    'with the %s tag, possibly because grafted libraries '
                    'require more recent symbols.' %


### PR DESCRIPTION
Partially addresses #146.

This checks the output wheel from `auditwheel repair` for compatibility with the specified tag. This is not an ideal fix, because the output wheel is produced even if it's invalid. But producing an error means that it will fail in testing & CI environments, which probably mitigates the problem in many situations.

A better fix would involve either checking the libraries as they are grafted in, or producing the wheel initially into a temporary folder, and only copying it to the output directory if it passes the check.

This builds on the branch in #147.

