### PR TITLE
Make it possible to run the test suite on non-Linux systems

### DIFF
--- a/auditwheel/main.py
+++ b/auditwheel/main.py
@@ -11,6 +11,10 @@ from . import main_repair
 
 
 def main():
+    if sys.platform != 'linux':
+        print('Error: This tool only supports Linux')
+        return 1
+
     dist = pkg_resources.get_distribution('auditwheel')
     version = 'auditwheel %s installed at %s (python %s)' % (
         dist.version, dist.location, sys.version[:3])

--- a/auditwheel/policy/__init__.py
+++ b/auditwheel/policy/__init__.py
@@ -27,13 +27,6 @@ _PLATFORM_REPLACEMENT_MAP = {
     'manylinux2010_i686': ['linux_i686'],
 }
 
-# XXX: this could be weakened. The show command _could_ run on OS X or
-# Windows probably, but there's not much reason to inspect foreign package
-# that won't run on the platform.
-# if platform != 'linux':
-#     logger.critical('Error: This tool only supports Linux')
-#     sys.exit(1)
-
 
 def get_arch_name():
     if _platform_module.machine() in non_x86_linux_machines:


### PR DESCRIPTION
At the moment the platform check is done when the policy module gets
imported. This makes it difficult to run the test suite on non-Linux
platforms. Moving the check to the CLI entry point allows the tests to
run and retains the current behavior and exits on non-Linux platforms
when running the tool.

Note that in a previous commit I accidentally commented out the check,
that's why it's shown commented in this diff.

Closes: #154 