### PR TITLE
Improve error message on invalid package

### DIFF
--- a/auditwheel/genericpkgctx.py
+++ b/auditwheel/genericpkgctx.py
@@ -13,4 +13,5 @@ def InGenericPkgCtx(in_path, out_path=None):
             raise NotImplementedError()
         return InCondaPkgCtx(in_path)
 
-    raise ValueError(in_path)
+    raise ValueError("Invalid package: %s. File formats supported: "
+                     ".whl, .tar.bz2" % in_path)


### PR DESCRIPTION
Instead of raising an empty ValueError when encountering an unknown file format, provide a meaningful error message in the exception. This should make it easier for users to tell what went wrong.