### PR TITLE
Use pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "pbr"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-setuptools
 wheel == 0.31.1
 typing >=3.5.0.1
 pyelftools >=0.24

--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -195,7 +195,7 @@ def test_build_wheel_with_binary_executable(docker_container):
     policy, manylinux_id, python_id, io_folder = docker_container
     docker_exec(manylinux_id, 'yum install -y gsl-devel')
 
-    docker_exec(manylinux_id, ['bash', '-c', 'cd /auditwheel_src/tests/testpackage && python setup.py bdist_wheel -d /io'])
+    docker_exec(manylinux_id, ['bash', '-c', 'cd /auditwheel_src/tests/testpackage && python -m pip wheel --no-deps -w /io .'])
 
     filenames = os.listdir(io_folder)
     assert filenames == ['testpackage-0.0.1-py3-none-any.whl']


### PR DESCRIPTION
Make setuptools a build dependency in pyproject.toml and set it as the
build backend.