### PR TITLE
Remove typing from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 wheel == 0.31.1
-typing >=3.5.0.1
 pyelftools >=0.24


### PR DESCRIPTION
This the backport library needed for pre-3.5 interpreters only. Since we
only support 3.5 and later, it can be removed.