### PR TITLE
WIP: Codecov integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[paths]
+source =
+    auditwheel/
+    /auditwheel_src/auditwheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 
 install:
   - pip install -r test-requirements.txt
-  - pip install tox
+  - pip install tox codecov
   - pip install .
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ before_install:
 install:
   - pip install -r test-requirements.txt
   - pip install tox codecov
-  - pip install .
-
+  - pip install -e .
 
 script:
   - tests/travis.sh

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -7,7 +7,7 @@ if [[ "$WHEELHOUSE" == "1" ]]; then
 elif [[ "$LINTER" == "1" ]]; then
     tox -e lint
 else
-    pytest -s --cov auditwheel
+    pytest -s --cov auditwheel --cov-branch
     auditwheel lddtree $(python -c 'import sys; print(sys.executable)')
     codecov || true  # Ignore failures from codecov tool
 fi

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -7,6 +7,7 @@ if [[ "$WHEELHOUSE" == "1" ]]; then
 elif [[ "$LINTER" == "1" ]]; then
     tox -e lint
 else
-    pytest -s
+    pytest -s --cov auditwheel
     auditwheel lddtree $(python -c 'import sys; print(sys.executable)')
+    codecov || true  # Ignore failures from codecov tool
 fi


### PR DESCRIPTION
Try to collect code coverage information & report it through codecov. This is what the results look like: https://codecov.io/gh/pypa/auditwheel/branch/codecov

I think this is only reporting coverage from the unit tests at the moment. I'd like to try to figure out including coverage from the integration tests which run auditwheel inside docker containers, but that will probably be a bit more involved.

I did have to switch to an editable install in Travis. It seems awkward to match up the executed code with the source files otherwise.