### PR TITLE
Always change rpath of grafted libraries

### DIFF
--- a/auditwheel/repair.py
+++ b/auditwheel/repair.py
@@ -145,10 +145,8 @@ def copylib(src_path, dest_dir):
     check_call(['patchelf', '--set-soname', new_soname, dest_path])
 
     for rp in itertools.chain(rpaths['rpaths'], rpaths['runpaths']):
-        if is_subdir(rp, os.path.dirname(src_path)):
-            patchelf_set_rpath(dest_path, pjoin(
-                dirname(dest_path), relpath(rp, dirname(src_path))))
-            break
+        patchelf_set_rpath(dest_path, dest_dir)
+        break
 
     return new_soname, dest_path
 

--- a/auditwheel/repair.py
+++ b/auditwheel/repair.py
@@ -144,9 +144,8 @@ def copylib(src_path, dest_dir):
     verify_patchelf()
     check_call(['patchelf', '--set-soname', new_soname, dest_path])
 
-    for rp in itertools.chain(rpaths['rpaths'], rpaths['runpaths']):
+    if any(itertools.chain(rpaths['rpaths'], rpaths['runpaths'])):
         patchelf_set_rpath(dest_path, dest_dir)
-        break
 
     return new_soname, dest_path
 

--- a/auditwheel/repair.py
+++ b/auditwheel/repair.py
@@ -120,8 +120,8 @@ def copylib(src_path, dest_dir):
     location.
     """
     # Copy the a shared library from the system (src_path) into the wheel
-    # if the library has a RUNPATH/RPATH to it's current location on the
-    # system, we also update that to point to its new location.
+    # if the library has a RUNPATH/RPATH we also update that to point to its
+    # new location.
 
     with open(src_path, 'rb') as f:
         shorthash = hashfile(f)[:8]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,3 +6,4 @@ pypatchelf
 flake8
 pretend
 docker
+pyelftools

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -406,6 +406,7 @@ def test_build_wheel_depending_on_library_with_rpath(any_manylinux_container, do
                 with w.open(name) as f:
                     elf = ELFFile(io.BytesIO(f.read()))
                     dynamic = elf.get_section_by_name('.dynamic')
-                    tags = {t.entry.d_tag for t in dynamic.iter_tags()}
                     if '.libs/liba' in name:
-                        assert 'DT_RPATH' in tags
+                        rpath_tags = [t for t in dynamic.iter_tags() if t.entry.d_tag == 'DT_RPATH']
+                        assert len(rpath_tags) == 1
+                        assert rpath_tags[0].rpath == '$ORIGIN/.'

--- a/tests/integration/testrpath/MANIFEST.in
+++ b/tests/integration/testrpath/MANIFEST.in
@@ -1,0 +1,2 @@
+graft a
+graft b

--- a/tests/integration/testrpath/a/a.c
+++ b/tests/integration/testrpath/a/a.c
@@ -1,0 +1,6 @@
+#include "b.h"
+
+
+int fa(void) {
+    return 1 + fb();
+}

--- a/tests/integration/testrpath/a/a.h
+++ b/tests/integration/testrpath/a/a.h
@@ -1,0 +1,1 @@
+int fa(void);

--- a/tests/integration/testrpath/b/b.c
+++ b/tests/integration/testrpath/b/b.c
@@ -1,0 +1,3 @@
+int fb(void) {
+    return 10;
+}

--- a/tests/integration/testrpath/b/b.h
+++ b/tests/integration/testrpath/b/b.h
@@ -1,0 +1,1 @@
+int fb(void);

--- a/tests/integration/testrpath/setup.py
+++ b/tests/integration/testrpath/setup.py
@@ -1,0 +1,27 @@
+from setuptools import setup, Extension
+import subprocess
+
+cmd = 'gcc -fPIC -shared -o b/libb.so b/b.c'
+subprocess.check_call(cmd.split())
+cmd = (
+    'gcc -fPIC -shared -o a/liba.so '
+    '-Wl,--disable-new-dtags -Wl,-rpath=$ORIGIN/../b '
+    '-Ib -Lb -lb a/a.c'
+)
+subprocess.check_call(cmd.split())
+
+setup(
+    name='testrpath',
+    version='0.0.1',
+    packages=['testrpath'],
+    package_dir={'': 'src'},
+    ext_modules=[
+        Extension(
+            'testrpath/testrpath',
+            sources=['src/testrpath/testrpath.c'],
+            include_dirs=['a'],
+            libraries=['a'],
+            library_dirs=['a'],
+        )
+    ],
+)

--- a/tests/integration/testrpath/src/testrpath/testrpath.c
+++ b/tests/integration/testrpath/src/testrpath/testrpath.c
@@ -1,0 +1,31 @@
+#include <Python.h>
+#include "a.h"
+
+static PyObject *
+func(PyObject *self, PyObject *args)
+{
+    int res;
+
+    (void)self;
+    (void)args;
+
+    res = fa();
+    return PyLong_FromLong(res);
+}
+
+/* Module initialization */
+PyMODINIT_FUNC PyInit_testrpath(void)
+{
+    static PyMethodDef module_methods[] = {
+        {"func", (PyCFunction)func, METH_NOARGS, "func."},
+        {NULL}  /* Sentinel */
+    };
+    static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "testrpath",
+        "testrpath module",
+        -1,
+        module_methods,
+    };
+    return PyModule_Create(&moduledef);
+}

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = py35,py36,py37,lint,cov
 [testenv]
 deps = .
        -r{toxinidir}/test-requirements.txt
-commands =  pytest --doctest-modules auditwheel tests []
+commands =  pytest --doctest-modules auditwheel tests
 
 [testenv:lint]
 commands = flake8 auditwheel

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = py35,py36,py37,lint,cov
 [testenv]
 deps = .
        -r{toxinidir}/test-requirements.txt
-commands =  pytest --doctest-modules auditwheel tests
+commands =  pytest --doctest-modules auditwheel tests []
 
 [testenv:lint]
 commands = flake8 auditwheel


### PR DESCRIPTION
If collected library has ``RPATH`` or ``RUNPATH`` set now ``auditwheel`` changes it to a new location of all collected libraries.
This patch is extracted from #133 to make that pull request focused on only one thing.