### PR TITLE
Add ability to pass options to pytest in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = py35,py36,py37,lint,cov
 [testenv]
 deps = .
        -r{toxinidir}/test-requirements.txt
-commands =  pytest --doctest-modules auditwheel tests
+commands =  pytest --doctest-modules auditwheel tests []
 
 [testenv:lint]
 commands = flake8 auditwheel


### PR DESCRIPTION
This pull request adds ability to specify options passed to underlying ``pytest`` command when running ``tox``.