### PR TITLE
Clear rpath before setting

### DIFF
--- a/auditwheel/repair.py
+++ b/auditwheel/repair.py
@@ -116,12 +116,12 @@ def copylib(src_path, dest_dir):
 
     1) Copy the file from src_path to dest_dir/
     2) Rename the shared object from soname to soname.<unique>
-    3) If the library has a RUNPATH/RPATH, update that to point to its new
-    location.
+    3) If the library has a RUNPATH/RPATH, clear it and set RPATH to point to
+    its new location.
     """
     # Copy the a shared library from the system (src_path) into the wheel
-    # if the library has a RUNPATH/RPATH we also update that to point to its
-    # new location.
+    # if the library has a RUNPATH/RPATH we clear it and set RPATH to point to
+    # its new location.
 
     with open(src_path, 'rb') as f:
         shorthash = hashfile(f)[:8]
@@ -153,4 +153,5 @@ def copylib(src_path, dest_dir):
 def patchelf_set_rpath(fn, libdir):
     rpath = pjoin('$ORIGIN', relpath(libdir, dirname(fn)))
     logger.debug('Setting RPATH: %s to "%s"', fn, rpath)
+    check_call(['patchelf', '--remove-rpath', fn])
     check_call(['patchelf', '--force-rpath', '--set-rpath', rpath, fn])

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -351,7 +351,12 @@ def test_build_repair_pure_wheel(any_manylinux_container, io_folder):
 @pytest.mark.parametrize('dtag', ['rpath', 'runpath'])
 def test_build_wheel_depending_on_library_with_rpath(any_manylinux_container, docker_python,
                                                      io_folder, dtag):
-    # Test building a wheel that contains an extension depending on a library with RPATH set
+    # Test building a wheel that contains an extension depending on a library
+    # with RPATH or RUNPATH set.
+    # Following checks are performed:
+    # - check if RUNPATH is replaced by RPATH
+    # - check if RPATH location is correct, i.e. it is inside .libs directory
+    #   where all gathered libraries are put
 
     policy, manylinux_ctr = any_manylinux_container
 

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -416,13 +416,8 @@ def test_build_wheel_depending_on_library_with_rpath(any_manylinux_container, do
                 with w.open(name) as f:
                     elf = ELFFile(io.BytesIO(f.read()))
                     dynamic = elf.get_section_by_name('.dynamic')
-                    rpath = runpath = None
-                    for t in dynamic.iter_tags():
-                        if t.entry.d_tag == 'DT_RPATH':
-                            rpath = t
-                        elif t.entry.d_tag == 'DT_RUNPATH':
-                            runpath = t
-                    assert runpath is None
+                    assert len([t for t in dynamic.iter_tags() if t.entry.d_tag == 'DT_RUNPATH']) == 0
                     if '.libs/liba' in name:
-                        assert rpath is not None
-                        assert rpath.rpath == '$ORIGIN/.'
+                        rpath_tags = [t for t in dynamic.iter_tags() if t.entry.d_tag == 'DT_RPATH']
+                        assert len(rpath_tags) == 1
+                        assert rpath_tags[0].rpath == '$ORIGIN/.'

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -367,12 +367,11 @@ def test_build_wheel_depending_on_library_with_rpath(any_manylinux_container, do
             ).format(dtag),
         ]
     )
-    if dtag == 'runpath':
-        with open(op.join(op.dirname(__file__), 'testrpath', 'a', 'liba.so'), 'rb') as f:
-            elf = ELFFile(f)
-            dynamic = elf.get_section_by_name('.dynamic')
-            tags = {t.entry.d_tag for t in dynamic.iter_tags()}
-            assert 'DT_RUNPATH' in tags
+    with open(op.join(op.dirname(__file__), 'testrpath', 'a', 'liba.so'), 'rb') as f:
+        elf = ELFFile(f)
+        dynamic = elf.get_section_by_name('.dynamic')
+        tags = {t.entry.d_tag for t in dynamic.iter_tags()}
+        assert "DT_{}".format(dtag.upper()) in tags
     filenames = os.listdir(io_folder)
     assert filenames == ['testrpath-0.0.1-cp35-cp35m-linux_x86_64.whl']
     orig_wheel = filenames[0]

--- a/tests/integration/testrpath/setup.py
+++ b/tests/integration/testrpath/setup.py
@@ -1,12 +1,19 @@
 from setuptools import setup, Extension
+import os
 import subprocess
 
 cmd = 'gcc -fPIC -shared -o b/libb.so b/b.c'
 subprocess.check_call(cmd.split())
 cmd = (
     'gcc -fPIC -shared -o a/liba.so '
-    '-Wl,--disable-new-dtags -Wl,-rpath=$ORIGIN/../b '
+    '-Wl,{dtags_flag} -Wl,-rpath=$ORIGIN/../b '
     '-Ib -Lb -lb a/a.c'
+).format(
+    dtags_flag=(
+        '--enable-new-dtags'
+        if os.getenv('DTAG') == 'runpath'
+        else '--disable-new-dtags'
+    )
 )
 subprocess.check_call(cmd.split())
 


### PR DESCRIPTION
Due to bug in patchelf https://github.com/NixOS/patchelf/issues/94 if shared object has DT_RUNPATH attribute it is not replaced with DT_RPATH if --force-rpath is given, so one must clear all rpath attributes before setting new.
This pull request closes #29.
Also this pull request is resubmit of #133 because old showed too much changed files and it is easier for me to resubmit.