### PR TITLE
Fix deprecation warning

### DIFF
--- a/auditwheel/wheel_abi.py
+++ b/auditwheel/wheel_abi.py
@@ -3,6 +3,8 @@ import json
 import logging
 import functools
 import os
+from collections import defaultdict, namedtuple
+from collections.abc import Mapping
 from copy import deepcopy
 from os.path import basename
 from typing import Dict, Set
@@ -15,12 +17,6 @@ from .elfutils import (elf_file_filter, elf_find_versioned_symbols,
 from .policy import (lddtree_external_references, versioned_symbols_policy,
                      get_policy_name, POLICY_PRIORITY_LOWEST,
                      POLICY_PRIORITY_HIGHEST, load_policies)
-
-try:
-    from collections.abc import defaultdict, Mapping, namedtuple
-except ImportError:
-    # Pre-Python 3.7 compatibility
-    from collections import defaultdict, Mapping, namedtuple
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
```
auditwheel/wheel_abi.py:23: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import defaultdict, Mapping, namedtuple
```