### PR TITLE
Make integration tests faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,7 @@ install:
 
 script:
   - tests/travis.sh
+
+cache:
+  directories:
+    - $HOME/.cache/auditwheel_tests

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,22 @@ Limitations
    So, to compile widely-compatible binaries, you're best off doing the build
    on an old Linux distribution, such as the manylinux Docker image.
 
+Testing
+-------
+
+The tests can be run with ``tox``, which will automatically install
+test dependencies.
+
+Some of the integration tests also require a running and accessible Docker
+daemon. These tests will pull a number of docker images if they are not already
+available on your system, but it won't update existing images.
+To update these images manually, run::
+
+    docker pull python:3.5
+    docker pull quay.io/pypa/manylinux1_x86_64
+    docker pull quay.io/pypa/manylinux2010_x86_64
+
+You may also remove these images using ``docker rmi``.
 
 Code of Conduct
 ---------------

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -59,8 +59,6 @@ def docker_start(image, volumes={}, env_variables={}):
     """
     # Make sure to use the latest public version of the docker image
     client = docker.from_env()
-    logger.info("Pulling docker image %r", image)
-    client.images.pull(image)
 
     dvolumes = {host: {'bind': ctr, 'mode': 'rw'}
                 for (ctr, host) in volumes.items()}
@@ -73,11 +71,14 @@ def docker_start(image, volumes={}, env_variables={}):
 
 
 @contextmanager
-def docker_container_ctx(image, io_dir, env_variables={}):
+def docker_container_ctx(image, io_dir=None, env_variables={}):
     src_folder = find_src_folder()
     if src_folder is None:
         pytest.skip('Can only be run from the source folder')
-    vols = {'/io': io_dir, '/auditwheel_src': src_folder}
+    vols = {'/auditwheel_src': src_folder}
+    if io_dir is not None:
+        vols['/io'] = io_dir
+
     for key in env_variables:
         if key.startswith('COV_CORE_'):
             env_variables[key] = env_variables[key].replace(src_folder,
@@ -95,6 +96,7 @@ def docker_exec(container, cmd):
     ec, output = container.exec_run(cmd)
     output = output.decode(ENCODING)
     if ec != 0:
+        print(output)
         raise CalledProcessError(ec, cmd, output=output)
     return output
 
@@ -105,26 +107,69 @@ def io_folder(tmp_path):
     d.mkdir(exist_ok=True)
     return str(d)
 
+@contextmanager
+def tmp_docker_image(base, commands, setup_env={}):
+    """Make a temporary docker image for tests
+
+    Pulls the *base* image, runs *commands* inside it with *setup_env*, and
+    commits the result as a new image. The image is removed on exiting the
+    context.
+
+    Making temporary images like this avoids each test having to re-run the
+    same container setup steps.
+    """
+    client = docker.from_env()
+    logger.info("Pulling docker image %r", base)
+    client.images.pull(base)
+
+    with docker_container_ctx(base, env_variables=setup_env) as con:
+        for cmd in commands:
+            docker_exec(con, cmd)
+        image = con.commit()
+
+    logger.info("Made image %s based on %s", image.short_id, base)
+    try:
+        yield image.short_id
+    finally:
+        client = image.client
+        client.images.remove(image.id)
+
+@pytest.fixture(scope='session')
+def docker_python_img():
+    """The Python base image with up-to-date pip"""
+    with tmp_docker_image(PYTHON_IMAGE_ID, ['pip install -U pip']) as img_id:
+        yield img_id
+
+@pytest.fixture(scope='session', params=MANYLINUX_IMAGES.keys())
+def any_manylinux_img(request):
+    """Each manylinux image, with auditwheel installed.
+
+    Plus up-to-date pip, setuptools and pytest-cov
+    """
+    policy = request.param
+    base = MANYLINUX_IMAGES[policy]
+    env = {'PATH': PATH[policy]}
+    with tmp_docker_image(base, [
+        'pip install -U pip setuptools pytest-cov',
+        'pip install -U -e /auditwheel_src',
+    ], env) as img_id:
+        yield policy, img_id
 
 @pytest.fixture()
-def docker_python(io_folder):
-    with docker_container_ctx(PYTHON_IMAGE_ID, io_folder) as container:
-        docker_exec(container, 'pip install -U pip')
+def docker_python(docker_python_img, io_folder):
+    with docker_container_ctx(docker_python_img, io_folder) as container:
         yield container
 
 
-@pytest.fixture(params=MANYLINUX_IMAGES.keys())
-def any_manylinux_container(request, io_folder):
-    policy = request.param
-    image = MANYLINUX_IMAGES[policy]
+@pytest.fixture()
+def any_manylinux_container(any_manylinux_img, io_folder):
+    policy, manylinux_img = any_manylinux_img
     env = {'PATH': PATH[policy]}
     for key in os.environ:
         if key.startswith('COV_CORE_'):
             env[key] = os.environ[key]
 
-    with docker_container_ctx(image, io_folder, env) as container:
-        docker_exec(container, 'pip install -U pip setuptools pytest-cov')
-        docker_exec(container, 'pip install -U -e /auditwheel_src')
+    with docker_container_ctx(manylinux_img, io_folder, env) as container:
         yield policy, container
 
 

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -118,10 +118,6 @@ def tmp_docker_image(base, commands, setup_env={}):
     Making temporary images like this avoids each test having to re-run the
     same container setup steps.
     """
-    client = docker.from_env()
-    logger.info("Pulling docker image %r", base)
-    client.images.pull(base)
-
     with docker_container_ctx(base, env_variables=setup_env) as con:
         for cmd in commands:
             docker_exec(con, cmd)


### PR DESCRIPTION
(Hopefully)

I noticed that all the tests which use docker repeat trying to pull the same images and do the same setup steps inside the containers. So this adds a layer of fixtures to create temporary docker images in session-scoped fixtures, deleting them when tests finish.

On my system, this makes the tests finish in under half the time they previously took (~800 seconds to ~320 seconds). It should also mean that all the docker based tests run in a consistent environment, even if an image is updated or a package released while the tests are running.

I've also told Travis to cache the wheels built in the tests. That won't affect the test time on this PR, because there's nothing cached yet, but once it's merged it should avoid the need to recompile numpy each time.