### PR TITLE
Fix --version for python 3.10

### DIFF
--- a/auditwheel/main.py
+++ b/auditwheel/main.py
@@ -16,8 +16,8 @@ def main():
         return 1
 
     dist = pkg_resources.get_distribution('auditwheel')
-    version = 'auditwheel %s installed at %s (python %s)' % (
-        dist.version, dist.location, sys.version[:3])
+    version = 'auditwheel {} installed at {} (python {}.{})'.format(
+        dist.version, dist.location, *sys.version_info)
 
     p = argparse.ArgumentParser(description='Cross-distro Python wheels.')
     p.set_defaults(prog=os.path.basename(sys.argv[0]))


### PR DESCRIPTION
found using [asottile/python3.10](https://github.com/asottile/python3.10)

### before

```console
$ .tox/py310/bin/auditwheel --version
auditwheel 2.1.1.dev2 installed at /tmp/x/repos/pypa/auditwheel (python 3.1)
```

### after

```console
$ .tox/py310/bin/auditwheel --version
auditwheel 2.1.1.dev2 installed at /tmp/x/repos/pypa/auditwheel (python 3.10)
```