### PR TITLE
Update machine detection

### DIFF
--- a/auditwheel/policy/__init__.py
+++ b/auditwheel/policy/__init__.py
@@ -8,9 +8,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-non_x86_linux_machines = {'armv6l', 'armv7l', 'ppc64le'}
-linkage = _platform_module.architecture()[1]
-
 # https://docs.python.org/3/library/platform.html#platform.architecture
 bits = 8 * (8 if sys.maxsize > 2 ** 32 else 4)
 
@@ -25,8 +22,9 @@ _PLATFORM_REPLACEMENT_MAP = {
 
 
 def get_arch_name():
-    if _platform_module.machine() in non_x86_linux_machines:
-        return _platform_module.machine()
+    machine = _platform_module.machine()
+    if machine not in {'x86_64', 'i686'}:
+        return machine
     else:
         return {64: 'x86_64', 32: 'i686'}[bits]
 

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -6,24 +6,30 @@ from auditwheel.policy import get_arch_name, get_policy_name, get_priority_by_na
 
 
 @patch("auditwheel.policy._platform_module.machine")
-@pytest.mark.parametrize("arch", [
-    "armv6l",
-    "armv7l",
-    "ppc64le",
-    "x86_64",
+@patch("auditwheel.policy.bits", 32)
+@pytest.mark.parametrize("reported_arch,expected_arch", [
+    ("armv6l", "armv6l"),
+    ("armv7l", "armv7l"),
+    ("i686", "i686"),
+    ("x86_64", "i686"),
 ])
-def test_arch_name(machine_mock, arch):
-    machine_mock.return_value = arch
+def test_32bits_arch_name(machine_mock, reported_arch, expected_arch):
+    machine_mock.return_value = reported_arch
     machine = get_arch_name()
-    assert machine == arch
+    assert machine == expected_arch
 
 
 @patch("auditwheel.policy._platform_module.machine")
-@patch("auditwheel.policy.bits", 32)
-def test_unknown_arch_name(machine_mock):
-    machine_mock.return_value = "mipsel"
+@patch("auditwheel.policy.bits", 64)
+@pytest.mark.parametrize("reported_arch,expected_arch", [
+    ("aarch64", "aarch64"),
+    ("ppc64le", "ppc64le"),
+    ("x86_64", "x86_64"),
+])
+def test_64bits_arch_name(machine_mock, reported_arch, expected_arch):
+    machine_mock.return_value = reported_arch
     machine = get_arch_name()
-    assert machine == "i686"
+    assert machine == expected_arch
 
 
 class TestPolicyAccess:


### PR DESCRIPTION
All unknown machines were detected as `x86_64` or `i686` depending on their word size.
Update the detection in order to get the untouched machine name for those arch and only consider i686 running on x86_64 to be eligible to a name change.

Example:
before, `aarch64` was reported as `x86_64`, now `aarch64`