### PR TITLE
Add CHANGELOG.md entry for 3.0.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## HEAD
 
+## 3.0.0rc1
+
+Released Nov. 7, 2019
+
+### User-facing changes
+- [FEATURE] manylinux2014 policy ([#192](https://github.com/pypa/auditwheel/pull/192), [#202](https://github.com/pypa/auditwheel/pull/202))
+- [FEATURE] Update machine detection ([#201](https://github.com/pypa/auditwheel/pull/201))
+- [FEATURE] Advertise python 3.8 support and run python 3.8 in CI ([#203](https://github.com/pypa/auditwheel/pull/203))
+
+### Housekeeping
+- Run manylinux tests using current python version ([#199](https://github.com/pypa/auditwheel/pull/199))
+
 ## 2.1.1
 
 Released Oct. 08, 2019


### PR DESCRIPTION
relates to #205 

@di, I think I'll do a release candidate as a first step. That should allow the manylinux2014 image to be released and tested before releasing 3.0.0 a bit later.