### PR TITLE
Always exclude ELF dynamic linker/loader

### DIFF
--- a/auditwheel/elfutils.py
+++ b/auditwheel/elfutils.py
@@ -45,7 +45,8 @@ def elf_find_versioned_symbols(elf: ELFFile) -> Iterator[Tuple[str, str]]:
 
     if section is not None:
         for verneed, verneed_iter in section.iter_versions():
-            if verneed.name.startswith('ld-linux'):
+            if verneed.name.startswith('ld-linux') or \
+                    verneed.name in ['ld64.so.2', 'ld64.so.1']:
                 continue
             for vernaux in verneed_iter:
                 yield (verneed.name,

--- a/auditwheel/policy/external_references.py
+++ b/auditwheel/policy/external_references.py
@@ -16,8 +16,11 @@ def lddtree_external_references(lddtree: Dict, wheel_path: str):
 
     def filter_libs(libs, whitelist):
         for lib in libs:
-            if 'ld-linux' in lib:
-                # always exclude ld-linux.so
+            if 'ld-linux' in lib or lib in ['ld64.so.2', 'ld64.so.1']:
+                # always exclude ELF dynamic linker/loader
+                # 'ld64.so.2' on s390x
+                # 'ld64.so.1' on ppc64le
+                # 'ld-linux*' on other platforms
                 continue
             if LIBPYTHON_RE.match(lib):
                 # always exclude libpythonXY

--- a/tests/integration/testdependencies/dependency.c
+++ b/tests/integration/testdependencies/dependency.c
@@ -1,10 +1,12 @@
 #include "dependency.h"
 #include <malloc.h>
+#include <stdlib.h>
+#include <stdint.h>
 
 int dep_run()
 {
 #if defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 17)
-    return (int)secure_getenv("NON_EXISTING_ENV_VARIABLE");
+    return (int)(intptr_t)secure_getenv("NON_EXISTING_ENV_VARIABLE");
 #elif defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 10)
     return malloc_info(0, stdout);
 #else

--- a/tests/integration/testdependencies/setup.py
+++ b/tests/integration/testdependencies/setup.py
@@ -3,10 +3,10 @@ import subprocess
 from os import path
 from os import getenv
 
-cmd = 'gcc -shared -fPIC dependency.c -o libdependency.so'
+cmd = 'gcc -shared -fPIC -D_GNU_SOURCE dependency.c -o libdependency.so'
 subprocess.check_call(cmd.split())
 
-define_macros = []
+define_macros = [('_GNU_SOURCE', None)]
 libraries = []
 library_dirs = []
 

--- a/tests/integration/testdependencies/testdependencies.c
+++ b/tests/integration/testdependencies/testdependencies.c
@@ -2,6 +2,8 @@
 #include "dependency.h"
 #else
 #include <malloc.h>
+#include <stdlib.h>
+#include <stdint.h>
 #endif
 #include <Python.h>
 
@@ -16,7 +18,7 @@ run(PyObject *self, PyObject *args)
 #ifdef WITH_DEPENDENCY
     res = dep_run();
 #elif defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 17)
-    res = (int)secure_getenv("NON_EXISTING_ENV_VARIABLE");
+    res = (int)(intptr_t)secure_getenv("NON_EXISTING_ENV_VARIABLE");
 #elif defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 10)
     res = malloc_info(0, stdout);
 #else

--- a/tests/integration/testdependencies/testdependencies.c
+++ b/tests/integration/testdependencies/testdependencies.c
@@ -7,6 +7,8 @@
 #endif
 #include <Python.h>
 
+static __thread int tres = 0;
+
 static PyObject *
 run(PyObject *self, PyObject *args)
 {
@@ -24,7 +26,16 @@ run(PyObject *self, PyObject *args)
 #else
     res = 0;
 #endif
-    return PyLong_FromLong(res);
+    return PyLong_FromLong(res + tres);
+}
+
+static PyObject *
+set_tres(PyObject *self, PyObject *args)
+{
+    (void)self;
+    (void)args;
+    tres = 1;
+    return PyLong_FromLong(tres);
 }
 
 /* Module initialization */
@@ -32,6 +43,7 @@ PyMODINIT_FUNC PyInit_testdependencies(void)
 {
     static PyMethodDef module_methods[] = {
         {"run", (PyCFunction)run, METH_NOARGS, "run."},
+        {"set_tres", (PyCFunction)set_tres, METH_NOARGS, "set_tres."},
         {NULL}  /* Sentinel */
     };
     static struct PyModuleDef moduledef = {

--- a/tests/unit/test_elfutils.py
+++ b/tests/unit/test_elfutils.py
@@ -95,13 +95,16 @@ class TestElfFindVersionedSymbols:
         # THEN
         assert symbols == [("foo-lib", "foo-lib")]
 
-    def test_only_ld_linux(self):
+    @pytest.mark.parametrize('ld_name', ['ld-linux', 'ld64.so.2', 'ld64.so.1'])
+    def test_only_ld_linux(self, ld_name):
         # GIVEN
         elf = Mock()
         verneed = Mock()
-        verneed.configure_mock(name="ld-linux")
+        verneed.configure_mock(name=ld_name)
+        veraux = Mock()
+        veraux.configure_mock(name="foo-lib")
         elf.get_section_by_name.return_value.iter_versions.return_value = (
-            (verneed, []),
+            (verneed, [veraux]),
         )
 
         # WHEN


### PR DESCRIPTION
`s390x`/`ppc64le` ELF dynamic linkers do not start with `ld-linux`and therefore, were not excluded from analysis.

Relates to #212 
Fixes https://github.com/pypa/manylinux/issues/412

The tests did not reveal this issue and shall be updated. I don't know how to get this done since all symbols in the linker are private (or seem to be).

@wdirons, @st-pasha, any simple test we could include to reproduce this behavior in tests ?