### PR TITLE
Add Python 3.8 to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py35,py36,py37,lint,cov
+envlist = py35,py36,py37,py38,lint,cov
 
 [testenv]
 deps = .


### PR DESCRIPTION
We already support 3.8 but it was not listed in tox.ini.