### PR TITLE
Skip "quick_check_numpy.py" in pytest collection

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,1 @@
+collect_ignore = ["quick_check_numpy.py"]


### PR DESCRIPTION
This file is used in one of the Dockerized tests. However, pytest
invokes the `import numpy` statement while it is collecting the test
cases on setup. This import can fail if the host environment does not
have numpy installed.