### PR TITLE
test: Remove pin for pip

### DIFF
--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -146,7 +146,7 @@ def tmp_docker_image(base, commands, setup_env={}):
 @pytest.fixture(scope='session')
 def docker_python_img():
     """The Python base image with up-to-date pip"""
-    with tmp_docker_image(PYTHON_IMAGE_ID, ['pip install pip==19.3.1']) as img_id:
+    with tmp_docker_image(PYTHON_IMAGE_ID, ['pip install pip']) as img_id:
         yield img_id
 
 @pytest.fixture(scope='session', params=MANYLINUX_IMAGES.keys())
@@ -159,7 +159,7 @@ def any_manylinux_img(request):
     base = MANYLINUX_IMAGES[policy]
     env = {'PATH': PATH[policy]}
     with tmp_docker_image(base, [
-        'pip install -U pip==19.3.1 setuptools pytest-cov',
+        'pip install -U pip setuptools pytest-cov',
         'pip install -U -e /auditwheel_src',
     ], env) as img_id:
         yield policy, img_id


### PR DESCRIPTION
Now that pip 20.0.2 is out we can remove the version pin in the tests.

Related: #219 