### PR TITLE
Fix obsolete wheel usage in addtag

### DIFF
--- a/auditwheel/main_addtag.py
+++ b/auditwheel/main_addtag.py
@@ -22,13 +22,13 @@ def configure_parser(sub_parsers):
 
 def execute(args, p):
     import os
-    from wheel.install import WHEEL_INFO_RE  # type: ignore
+    from wheel.wheelfile import WHEEL_INFO_RE  # type: ignore
     from .wheeltools import InWheelCtx, add_platforms, WheelToolsError
     from .wheel_abi import analyze_wheel_abi
 
     wheel_abi = analyze_wheel_abi(args.WHEEL_FILE)
 
-    parsed_fname = WHEEL_INFO_RE(basename(args.WHEEL_FILE))
+    parsed_fname = WHEEL_INFO_RE.search(basename(args.WHEEL_FILE))
     in_fname_tags = parsed_fname.groupdict()['plat'].split('.')
 
     logger.info('%s receives the following tag: "%s".',

--- a/tests/integration/test_addtag.py
+++ b/tests/integration/test_addtag.py
@@ -1,0 +1,12 @@
+from unittest.mock import Mock
+from pathlib import Path
+
+from auditwheel.main_addtag import execute
+
+HERE = Path(__file__).parent.resolve()
+
+def test_smoke(tmpdir):
+    """Simple test to exercise the 'addtag' code path"""
+    args = Mock(WHEEL_FILE=str(HERE / "cffi-1.5.0-cp27-none-linux_x86_64.whl"),
+                WHEEL_DIR=str(tmpdir / "wheelhouse/"))
+    execute(args, None)


### PR DESCRIPTION
We upgraded to wheel 0.34.1 and the API is slightly different. The
addtag command was not updated for the change.

The included test fails without the fix.