### PR TITLE
Create ELF patcher interface 

### DIFF
--- a/auditwheel/condatools.py
+++ b/auditwheel/condatools.py
@@ -31,4 +31,4 @@ class InCondaPkgCtx(InCondaPkg):
     def iter_files(self):
         files = os.path.join(self.path, 'info', 'files')
         with open(files) as f:
-            return [native(l.strip()) for l in f.readlines()]
+            return [native(line.strip()) for line in f.readlines()]

--- a/auditwheel/patcher.py
+++ b/auditwheel/patcher.py
@@ -1,0 +1,66 @@
+import re
+from distutils.spawn import find_executable
+from subprocess import check_call, check_output, CalledProcessError
+
+
+class ElfPatcher:
+    def replace_needed(self,
+                       file_name: str,
+                       so_name: str,
+                       new_so_name: str) -> None:
+        raise NotImplementedError
+
+    def set_soname(self,
+                   file_name: str,
+                   new_so_name: str) -> None:
+        raise NotImplementedError
+
+    def set_rpath(self,
+                  file_name: str,
+                  rpath: str) -> None:
+        raise NotImplementedError
+
+
+def _verify_patchelf() -> None:
+    """This function looks for the ``patchelf`` external binary in the PATH,
+    checks for the required version, and throws an exception if a proper
+    version can't be found. Otherwise, silcence is golden
+    """
+    if not find_executable('patchelf'):
+        raise ValueError('Cannot find required utility `patchelf` in PATH')
+    try:
+        version = check_output(['patchelf', '--version']).decode("utf-8")
+    except CalledProcessError:
+        raise ValueError('Could not call `patchelf` binary')
+
+    m = re.match(r'patchelf\s+(\d+(.\d+)?)', version)
+    if m and tuple(int(x) for x in m.group(1).split('.')) >= (0, 9):
+        return
+    raise ValueError(('patchelf %s found. auditwheel repair requires '
+                      'patchelf >= 0.9.') %
+                     version)
+
+
+class Patchelf(ElfPatcher):
+    def __init__(self):
+        _verify_patchelf()
+
+    def replace_needed(self,
+                       file_name: str,
+                       so_name: str,
+                       new_so_name: str) -> None:
+        check_call(['patchelf', '--replace-needed', so_name, new_so_name,
+                    file_name])
+
+    def set_soname(self,
+                   file_name: str,
+                   new_so_name: str) -> None:
+        check_call(['patchelf', '--set-soname', new_so_name, file_name])
+
+    def set_rpath(self,
+                  file_name: str,
+                  rpath: str) -> None:
+
+        check_call(['patchelf', '--remove-rpath', file_name])
+        check_call(['patchelf', '--force-rpath', '--set-rpath',
+                    rpath, file_name])

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -212,7 +212,8 @@ def test_build_repair_numpy(any_manylinux_container, docker_python, io_folder):
 
     # Repair the wheel using the manylinux container
     repair_command = (
-        'auditwheel repair --plat {policy} -w /io /io/{orig_wheel}'
+        'auditwheel repair  '
+        '--plat {policy} -w /io /io/{orig_wheel}'
     ).format(policy=policy, orig_wheel=orig_wheel)
     docker_exec(manylinux_ctr, repair_command)
     filenames = os.listdir(io_folder)

--- a/tests/unit/test_elfpatcher.py
+++ b/tests/unit/test_elfpatcher.py
@@ -1,0 +1,67 @@
+from subprocess import CalledProcessError
+from unittest.mock import patch, call
+
+import pytest
+
+from auditwheel.patcher import Patchelf
+
+
+@patch("auditwheel.patcher.find_executable")
+def test_patchelf_unavailable(find_executable):
+    find_executable.return_value = False
+    with pytest.raises(ValueError):
+        Patchelf()
+
+
+@patch("auditwheel.patcher.check_output")
+def test_patchelf_check_output_fail(check_output):
+    check_output.side_effect = CalledProcessError(1, "patchelf --version")
+    with pytest.raises(ValueError, match="Could not call"):
+        Patchelf()
+
+
+@patch("auditwheel.patcher.check_output")
+@pytest.mark.parametrize("version", ["0.9", "0.9.1", "0.10"])
+def test_patchelf_version_check(check_output, version):
+    check_output.return_value.decode.return_value = "patchelf {}".format(version)
+    Patchelf()
+
+
+@patch("auditwheel.patcher.check_output")
+@pytest.mark.parametrize("version", ["0.8", "0.8.1", "0.1"])
+def test_patchelf_version_check_fail(check_output, version):
+    check_output.return_value.decode.return_value = "patchelf {}".format(version)
+    with pytest.raises(ValueError, match="patchelf {} found".format(version)):
+        Patchelf()
+
+
+@patch("auditwheel.patcher._verify_patchelf")
+@patch("auditwheel.patcher.check_call")
+class TestPatchElf:
+    """"Validate that patchelf is invoked with the correct arguments."""
+
+    def test_replace_needed(self, check_call, _):
+        patcher = Patchelf()
+        filename = "test.so"
+        soname_old = "TEST_OLD"
+        soname_new = "TEST_NEW"
+        patcher.replace_needed(filename, soname_old, soname_new)
+        check_call.assert_called_once_with(['patchelf', '--replace-needed',
+                                            soname_old, soname_new, filename])
+
+    def test_set_soname(self, check_call, _):
+        patcher = Patchelf()
+        filename = "test.so"
+        soname_new = "TEST_NEW"
+        patcher.set_soname(filename, soname_new)
+        check_call.assert_called_once_with(['patchelf', '--set-soname',
+                                            soname_new, filename])
+
+    def test_set_rpath(self, check_call, _):
+        patcher = Patchelf()
+        patcher.set_rpath("test.so", "$ORIGIN/.lib")
+        expected_args = [call(['patchelf', '--remove-rpath', 'test.so']),
+                         call(['patchelf', '--force-rpath', '--set-rpath',
+                               '$ORIGIN/.lib', 'test.so'])]
+
+        assert check_call.call_args_list == expected_args


### PR DESCRIPTION
This adds the ELF patcher interface from #187 to decouple the patching from the main repair logic and make it easier to add new ELF binary patcher implementations.