### PR TITLE
check that path isfile in find_lib

### DIFF
--- a/auditwheel/lddtree.py
+++ b/auditwheel/lddtree.py
@@ -256,7 +256,7 @@ def find_lib(elf, lib, ldpaths, root='/'):
         path = os.path.join(ldpath, lib)
         target = readlink(path, root, prefixed=True)
 
-        if os.path.exists(target):
+        if os.path.exists(target) and os.path.isfile(target):
             with open(target, 'rb') as f:
                 libelf = ELFFile(f)
                 if compatible_elfs(elf, libelf):


### PR DESCRIPTION
`auditwheel repair` would fail with

`IsADirectoryError: Is a directory: '/tmp/<hash>/<pkgname>.libs'`

Add check that target is a file rather than a directory. a v minor change fixes.

hopefully simple, if i'm pulling incorrectly feel free to just reject