### PR TITLE
Drop python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 
 jobs:
   include:
-  - python: "3.5"
   - python: "3.6"
   - python: "3.7"
   - python: "3.8"

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Installation
 
   $ pip3 install auditwheel
 
-It requires Python 3.5+, and runs on Linux. It requires that the shell command
+It requires Python 3.6+, and runs on Linux. It requires that the shell command
 ``unzip`` be available in the ``PATH``. Only systems that use `ELF
 <https://en.wikipedia.org/wiki/Executable_and_Linkable_Format>`_-based linkage
 are supported (this should be essentially every Linux).
@@ -130,7 +130,7 @@ daemon. These tests will pull a number of docker images if they are not already
 available on your system, but it won't update existing images.
 To update these images manually, run::
 
-    docker pull python:3.5
+    docker pull python:3.6
     docker pull quay.io/pypa/manylinux1_x86_64
     docker pull quay.io/pypa/manylinux2010_x86_64
     docker pull quay.io/pypa/manylinux2014_x86_64

--- a/auditwheel/policy/__init__.py
+++ b/auditwheel/policy/__init__.py
@@ -15,16 +15,16 @@ bits = 8 * (8 if sys.maxsize > 2 ** 32 else 4)
 _PLATFORM_REPLACEMENT_MAP = {}
 for _policy in {'manylinux1', 'manylinux2010'}:
     for _arch in {'x86_64', 'i686'}:
-        _key = '{}_{}'.format(_policy, _arch)
-        _value = 'linux_{}'.format(_arch)
+        _key = f'{_policy}_{_arch}'
+        _value = f'linux_{_arch}'
         _PLATFORM_REPLACEMENT_MAP[_key] = [_value]
 
 for _policy in {'manylinux2014'}:
     for _arch in {
         'x86_64', 'i686', 'aarch64', 'armv7l', 'ppc64', 'ppc64le', 's390x'
     }:
-        _key = '{}_{}'.format(_policy, _arch)
-        _value = 'linux_{}'.format(_arch)
+        _key = f'{_policy}_{_arch}'
+        _value = f'linux_{_arch}'
         _PLATFORM_REPLACEMENT_MAP[_key] = [_value]
 
 

--- a/auditwheel/repair.py
+++ b/auditwheel/repair.py
@@ -183,15 +183,15 @@ def _is_valid_rpath(rpath: str,
                     wheel_base_dir: str) -> bool:
     full_rpath_entry = _resolve_rpath_tokens(rpath, lib_dir)
     if not isabs(full_rpath_entry):
-        logger.debug('rpath entry {} could not be resolved to an absolute '
-                     'path -- discarding it.'.format(rpath))
+        logger.debug(f'rpath entry {rpath} could not be resolved to an '
+                     'absolute path -- discarding it.')
         return False
     elif not is_subdir(full_rpath_entry, wheel_base_dir):
-        logger.debug('rpath entry {} points outside the wheel -- discarding '
-                     'it.'.format(rpath))
+        logger.debug(f'rpath entry {rpath} points outside the wheel -- '
+                     'discarding it.')
         return False
     else:
-        logger.debug('Preserved rpath entry {}'.format(rpath))
+        logger.debug(f'Preserved rpath entry {rpath}')
         return True
 
 
@@ -207,6 +207,6 @@ def _resolve_rpath_tokens(rpath: str,
                           'LIB': system_lib_dir,
                           'PLATFORM': system_processor_type}
     for token, target in token_replacements.items():
-        rpath = rpath.replace('${}'.format(token), target)      # $TOKEN
-        rpath = rpath.replace('${{{}}}'.format(token), target)  # ${TOKEN}
+        rpath = rpath.replace(f'${token}', target)      # $TOKEN
+        rpath = rpath.replace(f'${{{token}}}', target)  # ${TOKEN}
     return rpath

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ author = Robert T. McGibbon
 author-email = rmcgibbo@gmail.com
 summary = Cross-distribution Linux wheels
 description-file = README.rst
-python_requires = >=3.5
+python_requires = >=3.6
 classifier =
         Development Status :: 4 - Beta
         Environment :: Console
@@ -14,7 +14,6 @@ classifier =
         License :: OSI Approved :: MIT License
         Operating System :: POSIX :: Linux
         Programming Language :: Python :: 3
-        Programming Language :: Python :: 3.5
         Programming Language :: Python :: 3.6
         Programming Language :: Python :: 3.7
         Programming Language :: Python :: 3.8

--- a/tests/integration/internal_rpath/setup.py
+++ b/tests/integration/internal_rpath/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=find_packages(),
     ext_modules=[
         Extension(
-            '{}.example_a'.format(package_name),
+            f'{package_name}.example_a',
             ['src/example_a.pyx'],
             include_dirs=['lib-src/a'],
             library_dirs=[package_name],
@@ -17,7 +17,7 @@ setup(
             extra_link_args=['-Wl,-rpath,$ORIGIN'],
         ),
         Extension(
-            '{}.example_b'.format(package_name),
+            f'{package_name}.example_b',
             ['src/example_b.pyx'],
             include_dirs=['lib-src/b'],
             library_dirs=['lib-src/b'],

--- a/tests/unit/test_elfpatcher.py
+++ b/tests/unit/test_elfpatcher.py
@@ -24,15 +24,15 @@ def test_patchelf_check_output_fail(check_output):
 @patch("auditwheel.patcher.check_output")
 @pytest.mark.parametrize("version", ["0.9", "0.9.1", "0.10"])
 def test_patchelf_version_check(check_output, version):
-    check_output.return_value.decode.return_value = "patchelf {}".format(version)
+    check_output.return_value.decode.return_value = f"patchelf {version}"
     Patchelf()
 
 
 @patch("auditwheel.patcher.check_output")
 @pytest.mark.parametrize("version", ["0.8", "0.8.1", "0.1"])
 def test_patchelf_version_check_fail(check_output, version):
-    check_output.return_value.decode.return_value = "patchelf {}".format(version)
-    with pytest.raises(ValueError, match="patchelf {} found".format(version)):
+    check_output.return_value.decode.return_value = f"patchelf {version}"
+    with pytest.raises(ValueError, match=f"patchelf {version} found"):
         Patchelf()
 
 

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -36,21 +36,21 @@ class TestPolicyAccess:
 
     def test_get_by_priority(self):
         _arch = get_arch_name()
-        assert get_policy_name(80) == 'manylinux2014_{}'.format(_arch)
+        assert get_policy_name(80) == f'manylinux2014_{_arch}'
         if _arch in {'x86_64', 'i686'}:
-            assert get_policy_name(90) == 'manylinux2010_{}'.format(_arch)
-            assert get_policy_name(100) == 'manylinux1_{}'.format(_arch)
-        assert get_policy_name(0) == 'linux_{}'.format(_arch)
+            assert get_policy_name(90) == f'manylinux2010_{_arch}'
+            assert get_policy_name(100) == f'manylinux1_{_arch}'
+        assert get_policy_name(0) == f'linux_{_arch}'
 
     def test_get_by_priority_missing(self):
         assert get_policy_name(101) is None
 
     def test_get_by_name(self):
         _arch = get_arch_name()
-        assert get_priority_by_name("manylinux2014_{}".format(_arch)) == 80
+        assert get_priority_by_name(f"manylinux2014_{_arch}") == 80
         if _arch in {'x86_64', 'i686'}:
-            assert get_priority_by_name("manylinux2010_{}".format(_arch)) == 90
-            assert get_priority_by_name("manylinux1_{}".format(_arch)) == 100
+            assert get_priority_by_name(f"manylinux2010_{_arch}") == 90
+            assert get_priority_by_name(f"manylinux1_{_arch}") == 100
 
     def test_get_by_name_missing(self):
         assert get_priority_by_name("nosuchpolicy") is None

--- a/tests/unit/test_repair.py
+++ b/tests/unit/test_repair.py
@@ -21,12 +21,13 @@ class TestRepair:
         check_output_expected_args = [call(['patchelf', '--print-rpath',
                                             full_lib_name])]
         # Then that entry is preserved when updating the RPATH
-        check_call_expected_args = [call(['patchelf', '--remove-rpath',
-                                          full_lib_name]),
-                                    call(['patchelf', '--force-rpath',
-                                          '--set-rpath',
-                                          '{}:$ORIGIN/.lib'.format(existing_rpath.decode()),
-                                          full_lib_name])]
+        check_call_expected_args = [
+            call(['patchelf', '--remove-rpath', full_lib_name]),
+            call([
+                'patchelf', '--force-rpath', '--set-rpath',
+                f'{existing_rpath.decode()}:$ORIGIN/.lib', full_lib_name
+            ])
+        ]
 
         assert check_output.call_args_list == check_output_expected_args
         assert check_call.call_args_list == check_call_expected_args

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py35,py36,py37,py38,lint,cov
+envlist = py36,py37,py38,lint,cov
 
 [testenv]
 deps = .


### PR DESCRIPTION
Python 3.5 reached its end-of-life, time to drop support.

Repairing python 3.5 wheels is still supported.