### PR TITLE
Add python 3.9 tests & advertise python 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ jobs:
   - python: "3.7"
   - python: "3.8"
   - python: "3.9"
-  - python: "3.7"
+  - python: "3.8"
     arch: arm64-graviton2
     virt: vm
     group: edge
-  - python: "3.7"
+  - python: "3.8"
     arch: ppc64le
-  - python: "3.7"
+  - python: "3.8"
     arch: s390x
-  - python: "3.7"
+  - python: "3.8"
     env: LINTER=1
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: bionic
+dist: focal
 language: python
 
 jobs:
@@ -9,7 +9,9 @@ jobs:
   - python: "3.8"
   - python: "3.9"
   - python: "3.7"
-    arch: arm64
+    arch: arm64-graviton2
+    virt: vm
+    group: edge
   - python: "3.7"
     arch: ppc64le
   - python: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ jobs:
   - python: "3.6"
   - python: "3.7"
   - python: "3.8"
+  - python: "3.9"
   - python: "3.7"
     arch: arm64
   - python: "3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifier =
         Programming Language :: Python :: 3.6
         Programming Language :: Python :: 3.7
         Programming Language :: Python :: 3.8
+        Programming Language :: Python :: 3.9
         Programming Language :: Python :: 3 :: Only
         Topic :: Software Development
         Topic :: Software Development :: Build Tools

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py36,py37,py38,lint,cov
+envlist = py36,py37,py38,py39,lint,cov
 
 [testenv]
 deps = .


### PR DESCRIPTION
This PR adds python 3.9 tests & advertise python 3.9 support.

I had failures with numpy tests on python 3.9 only thus I bumped the numpy version. This lead to timeouts on arm64 => switch to arm64-graviton2 for aarch64, always running on focal so also changed to focal as default distro. python 3.7 is missing on focal for ppc64le, s390x => use python 3.8 for non amd64 arch.