### PR TITLE
Modernize Python syntax using `pyupgrade --py36-plus`

### DIFF
--- a/auditwheel/condatools.py
+++ b/auditwheel/condatools.py
@@ -29,5 +29,5 @@ class InCondaPkgCtx(InCondaPkg):
 
     def iter_files(self):
         files = os.path.join(self.path, 'info', 'files')
-        with open(files, 'rt') as f:
+        with open(files) as f:
             return [line.strip() for line in f.readlines()]

--- a/auditwheel/lddtree.py
+++ b/auditwheel/lddtree.py
@@ -154,7 +154,7 @@ def parse_ld_so_conf(ldso_conf: str,
                                                   _first=False)
                 else:
                     paths += [normpath(root + line)]
-    except IOError as e:
+    except OSError as e:
         if e.errno != errno.ENOENT:
             log.warning(e)
 

--- a/auditwheel/main_show.py
+++ b/auditwheel/main_show.py
@@ -44,8 +44,8 @@ def execute(args, p):
 
     if get_priority_by_name(winfo.pyfpe_tag) < POLICY_PRIORITY_HIGHEST:
         printp('This wheel uses the PyFPE_jbuf function, which is not '
-                'compatible with the manylinux1 tag. (see '
-                'https://www.python.org/dev/peps/pep-0513/#fpectl-builds-vs-no-fpectl-builds)')  # noqa
+               'compatible with the manylinux1 tag. (see '
+               'https://www.python.org/dev/peps/pep-0513/#fpectl-builds-vs-no-fpectl-builds)')  # noqa
         if args.verbose < 1:
             return
 

--- a/auditwheel/main_show.py
+++ b/auditwheel/main_show.py
@@ -36,29 +36,29 @@ def execute(args, p):
         logger.info('This does not look like a platform wheel')
         return 1
 
-    libs_with_versions = ['%s with versions %s' % (k, v)
+    libs_with_versions = [f'{k} with versions {v}'
                           for k, v in winfo.versioned_symbols.items()]
 
     printp('%s is consistent with the following platform tag: "%s".' %
            (fn, winfo.overall_tag))
 
     if get_priority_by_name(winfo.pyfpe_tag) < POLICY_PRIORITY_HIGHEST:
-        printp(('This wheel uses the PyFPE_jbuf function, which is not '
+        printp('This wheel uses the PyFPE_jbuf function, which is not '
                 'compatible with the manylinux1 tag. (see '
-                'https://www.python.org/dev/peps/pep-0513/#fpectl-builds-vs-no-fpectl-builds)'))  # noqa
+                'https://www.python.org/dev/peps/pep-0513/#fpectl-builds-vs-no-fpectl-builds)')  # noqa
         if args.verbose < 1:
             return
 
     if get_priority_by_name(winfo.ucs_tag) < POLICY_PRIORITY_HIGHEST:
-        printp(('This wheel is compiled against a narrow unicode (UCS2) '
-                'version of Python, which is not compatible with the '
-                'manylinux1 tag.'))
+        printp('This wheel is compiled against a narrow unicode (UCS2) '
+               'version of Python, which is not compatible with the '
+               'manylinux1 tag.')
         if args.verbose < 1:
             return
 
     if len(libs_with_versions) == 0:
-        printp(("The wheel references no external versioned symbols from "
-                "system-provided shared libraries."))
+        printp('The wheel references no external versioned symbols from '
+               'system-provided shared libraries.')
     else:
         printp('The wheel references external versioned symbols in these '
                'system-provided shared libraries: %s' %
@@ -77,8 +77,8 @@ def execute(args, p):
     if len(libs) == 0:
         printp('The wheel requires no external shared libraries! :)')
     else:
-        printp(('The following external shared libraries are required '
-                'by the wheel:'))
+        printp('The following external shared libraries are required '
+               'by the wheel:')
         print(json.dumps(OrderedDict(sorted(libs.items())), indent=4))
 
     for p in sorted(load_policies(), key=lambda p: p['priority']):

--- a/auditwheel/repair.py
+++ b/auditwheel/repair.py
@@ -124,7 +124,7 @@ def copylib(src_path, dest_dir, patcher):
     src_name = os.path.basename(src_path)
     base, ext = src_name.split('.', 1)
     if not base.endswith('-%s' % shorthash):
-        new_soname = '%s-%s.%s' % (base, shorthash, ext)
+        new_soname = f'{base}-{shorthash}.{ext}'
     else:
         new_soname = src_name
 

--- a/auditwheel/tmpdirs.py
+++ b/auditwheel/tmpdirs.py
@@ -4,7 +4,7 @@ import os
 from tempfile import TemporaryDirectory
 
 
-class InTemporaryDirectory(object):
+class InTemporaryDirectory:
     ''' Create, return, and change directory to a temporary directory
 
     Examples

--- a/auditwheel/wheeltools.py
+++ b/auditwheel/wheeltools.py
@@ -166,9 +166,9 @@ class InWheelCtx(InWheel):
         if len(record_names) != 1:
             raise ValueError("Should be exactly one `*.dist_info` directory")
 
-        with open(record_names[0], 'rt') as f:
+        with open(record_names[0]) as f:
             record = f.read()
-        reader = csv.reader((r for r in record.splitlines()))
+        reader = csv.reader(r for r in record.splitlines())
         for row in reader:
             filename = row[0]
             yield filename


### PR DESCRIPTION
There were some things left from previous manual updates, use of `pyupgrade --py36-plus` found those:
 - Do not specify `mode=rt` for `open` as it is the default
 - Use `OSError` instead of `IOError`
 - Modernize class syntax
 - Convert some string formatting in f-strings