### PR TITLE
Fix: Patch RPATHs of non-Python extension dependencies

### DIFF
--- a/auditwheel/wheel_abi.py
+++ b/auditwheel/wheel_abi.py
@@ -118,10 +118,16 @@ def get_wheel_elfdata(wheel_fn: str):
             # we should walk its elftree.
             if basename(fn) not in needed_libs:
                 full_elftree[fn] = nonpy_elftree[fn]
-                full_external_refs[fn] = lddtree_external_references(
-                    nonpy_elftree[fn], ctx.path)
 
-    log.debug(json.dumps(full_elftree, indent=4))
+            # Even if a non-pyextension ELF file is not needed, we
+            # should include it as an external references, because
+            # they might also require external libraries.
+            full_external_refs[fn] = lddtree_external_references(
+                nonpy_elftree[fn], ctx.path)
+
+    log.debug('full_elftree:\n%s', json.dumps(full_elftree, indent=4))
+    log.debug('full_external_refs (will be repaired):\n%s',
+              json.dumps(full_external_refs, indent=4))
 
     return (full_elftree, full_external_refs, versioned_symbols,
             uses_ucs2_symbols, uses_PyFPE_jbuf)

--- a/auditwheel/wheel_abi.py
+++ b/auditwheel/wheel_abi.py
@@ -120,8 +120,8 @@ def get_wheel_elfdata(wheel_fn: str):
                 full_elftree[fn] = nonpy_elftree[fn]
 
             # Even if a non-pyextension ELF file is not needed, we
-            # should include it as an external references, because
-            # they might also require external libraries.
+            # should include it as an external reference, because
+            # it might require additional external libraries.
             full_external_refs[fn] = lddtree_external_references(
                 nonpy_elftree[fn], ctx.path)
 

--- a/tests/integration/nonpy_rpath/README.md
+++ b/tests/integration/nonpy_rpath/README.md
@@ -1,0 +1,9 @@
+# Python 3 extension with non-Python library dependency
+
+This example was inspired from https://gist.github.com/physacco/2e1b52415f3a964ad2a542a99bebed8f
+
+This test extension builds two libraries: `_nonpy_rpath.*.so` and `lib_cryptexample.*.so`, where the `*` is a string composed of Python ABI versions and platform tags.
+
+The extension `lib_cryptexample.*.so` should be repaired by auditwheel because it is a needed library, even though it is not a Python extension.
+
+[Issue #136](https://github.com/pypa/auditwheel/issues/136) documents the underlying problem that this test case is designed to solve.

--- a/tests/integration/nonpy_rpath/extensions/testcrypt.cpp
+++ b/tests/integration/nonpy_rpath/extensions/testcrypt.cpp
@@ -1,0 +1,6 @@
+#include "testcrypt.h"
+#include <crypt.h>
+
+std::string crypt_something() {
+    return std::string(crypt("will error out", NULL));
+}

--- a/tests/integration/nonpy_rpath/extensions/testcrypt.h
+++ b/tests/integration/nonpy_rpath/extensions/testcrypt.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <string>
+
+std::string crypt_something(void);

--- a/tests/integration/nonpy_rpath/nonpy_rpath.cpp
+++ b/tests/integration/nonpy_rpath/nonpy_rpath.cpp
@@ -1,0 +1,25 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include "extensions/testcrypt.h"
+
+// Module method definitions
+static PyObject* crypt_something(PyObject *self, PyObject *args) {
+    return PyUnicode_FromString(crypt_something().c_str());
+}
+
+/* Module initialization */
+PyMODINIT_FUNC PyInit__nonpy_rpath(void)
+{
+    static PyMethodDef module_methods[] = {
+        {"crypt_something", (PyCFunction)crypt_something, METH_NOARGS, "crypt_something."},
+        {NULL}  /* Sentinel */
+    };
+    static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "_nonpy_rpath",
+        "_nonpy_rpath module",
+        -1,
+        module_methods,
+    };
+    return PyModule_Create(&moduledef);
+}

--- a/tests/integration/nonpy_rpath/nonpy_rpath/__init__.py
+++ b/tests/integration/nonpy_rpath/nonpy_rpath/__init__.py
@@ -1,0 +1,3 @@
+from ._nonpy_rpath import crypt_something
+
+__all__ = ["crypt_something"]

--- a/tests/integration/nonpy_rpath/setup.py
+++ b/tests/integration/nonpy_rpath/setup.py
@@ -1,0 +1,98 @@
+import setuptools.command.build_ext
+from setuptools import setup, find_packages, Distribution
+from setuptools.extension import Extension, Library
+import os
+
+# despite its name, setuptools.command.build_ext.link_shared_object won't
+# link a shared object on Linux, but a static library and patches distutils
+# for this ... We're patching this back now.
+
+
+def always_link_shared_object(
+    self,
+    objects,
+    output_libname,
+    output_dir=None,
+    libraries=None,
+    library_dirs=None,
+    runtime_library_dirs=None,
+    export_symbols=None,
+    debug=0,
+    extra_preargs=None,
+    extra_postargs=None,
+    build_temp=None,
+    target_lang=None,
+):
+    self.link(
+        self.SHARED_LIBRARY,
+        objects,
+        output_libname,
+        output_dir,
+        libraries,
+        library_dirs,
+        runtime_library_dirs,
+        export_symbols,
+        debug,
+        extra_preargs,
+        extra_postargs,
+        build_temp,
+        target_lang,
+    )
+
+
+setuptools.command.build_ext.libtype = "shared"
+setuptools.command.build_ext.link_shared_object = always_link_shared_object
+
+libtype = setuptools.command.build_ext.libtype
+build_ext_cmd = Distribution().get_command_obj("build_ext")
+build_ext_cmd.initialize_options()
+build_ext_cmd.setup_shlib_compiler()
+
+
+def libname(name):
+    """ gets 'name' and returns something like libname.cpython-37m-darwin.so"""
+    filename = build_ext_cmd.get_ext_filename(name)
+    fn, ext = os.path.splitext(filename)
+    return build_ext_cmd.shlib_compiler.library_filename(fn, libtype)
+
+
+pkg_name = "nonpy_rpath"
+crypt_name = "_cryptexample"
+crypt_soname = libname(crypt_name)
+
+build_cmd = Distribution().get_command_obj("build")
+build_cmd.finalize_options()
+build_platlib = build_cmd.build_platlib
+
+
+def link_args(soname=None):
+    args = []
+    if soname:
+        args += ["-Wl,-soname," + soname]
+    loader_path = "$ORIGIN"
+    args += ["-Wl,-rpath," + loader_path]
+    return args
+
+
+nonpy_rpath_module = Extension(
+    pkg_name + "._nonpy_rpath",
+    language="c++",
+    sources=["nonpy_rpath.cpp"],
+    extra_link_args=link_args(),
+    extra_objects=[build_platlib + "/nonpy_rpath/" + crypt_soname],
+)
+crypt_example = Library(
+    pkg_name + "." + crypt_name,
+    language="c++",
+    extra_compile_args=["-lcrypt"],
+    extra_link_args=link_args(crypt_soname) + ["-lcrypt"],
+    sources=["extensions/testcrypt.cpp"],
+)
+
+setup(
+    name="nonpy_rpath",
+    version="0.1.0",
+    packages=find_packages(),
+    description="Test package for nonpy_rpath",
+    ext_modules=[crypt_example, nonpy_rpath_module],
+)


### PR DESCRIPTION
This PR resolves #136, and replaces the open (stalled) PR #139 from @thomaslima (closes #139) and rebase/rework the open PR #283 from @bdice (closes #283)

Summary in #283 is the nice one, so go there for more information.

Tests are much simpler here and still reproduce the issue without the fix of course.

Thanks @bdice, @thomaslima