### PR TITLE
Fix undeclared dependency on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,6 @@ from setuptools import setup
 
 setup(
     setup_requires=['pbr'],
+    install_requires=['setuptools'],
     pbr=True,
 )


### PR DESCRIPTION
auditwheel without setuptools raises:
`ModuleNotFoundError: No module named 'pkg_resources'`