### PR TITLE
Remove dependency on `pkg_resources`

### DIFF
--- a/auditwheel/main.py
+++ b/auditwheel/main.py
@@ -1,10 +1,15 @@
 import os
+import pathlib
 import sys
 import logging
 import argparse
-import pkg_resources
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata  # type: ignore
 from typing import Optional
 
+import auditwheel
 from . import main_show
 from . import main_addtag
 from . import main_lddtree
@@ -16,9 +21,9 @@ def main() -> Optional[int]:
         print('Error: This tool only supports Linux')
         return 1
 
-    dist = pkg_resources.get_distribution('auditwheel')
+    location = pathlib.Path(auditwheel.__file__).parent.resolve()
     version = 'auditwheel {} installed at {} (python {}.{})'.format(
-        dist.version, dist.location, *sys.version_info)
+        metadata.version("auditwheel"), location, *sys.version_info)
 
     p = argparse.ArgumentParser(description='Cross-distro Python wheels.')
     p.set_defaults(prog=os.path.basename(sys.argv[0]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyelftools>=0.24
+importlib_metadata; python_version < "3.8"


### PR DESCRIPTION
The only reason we needed this was to look at the version metadata and
the installation location. We can do this with `importlib.metadata`
which is part of Python since 3.8 and is significantly faster to import
than `pkg_resources`.

Closes: #306 