### PR TITLE
Add --include and --exclude options to auditwheel repair

### DIFF
--- a/auditwheel/main_repair.py
+++ b/auditwheel/main_repair.py
@@ -65,6 +65,12 @@ below.
                    action='store_true',
                    help='Strip symbols in the resulting wheel',
                    default=False)
+    p.add_argument('--include',
+                   dest='INCLUDE',
+                   help='Only include these libraries')
+    p.add_argument('--exclude',
+                   dest='EXCLUDE',
+                   help='Exclude these libraries')
     p.add_argument('--only-plat',
                    dest='ONLY_PLAT',
                    action='store_true',
@@ -126,7 +132,10 @@ def execute(args, p):
                              out_dir=args.WHEEL_DIR,
                              update_tags=args.UPDATE_TAGS,
                              patcher=patcher,
-                             strip=args.STRIP)
+                             strip=args.STRIP,
+                             include=(args.INCLUDE or '').split(','),
+                             exclude=(args.EXCLUDE or '').split(','),
+                             )
 
     if out_wheel is not None:
         logger.info('\nFixed-up wheel written to %s', out_wheel)

--- a/auditwheel/repair.py
+++ b/auditwheel/repair.py
@@ -34,8 +34,8 @@ def _is_in_list(soname: str, items: Optional[List[str]]) -> str:
             return item
 
 
-def _filter(l: List[str]) -> List[str]:
-    return [_.strip() for _ in l if _.strip()]
+def _filter(items: List[str]) -> List[str]:
+    return [_.strip() for _ in items if _.strip()]
 
 
 def repair_wheel(wheel_path: str, abis: List[str], lib_sdir: str, out_dir: str,

--- a/auditwheel/repair.py
+++ b/auditwheel/repair.py
@@ -28,14 +28,15 @@ WHEEL_INFO_RE = re.compile(
     re.VERBOSE).match
 
 
-def _is_in_list(soname: str, items: Optional[List[str]]) -> str:
-    for item in items:
+def _is_in_list(soname: str, items: Optional[List[str]]) -> Optional[str]:
+    for item in (items or []):
         if item in soname:
             return item
+    return None
 
 
-def _filter(items: List[str]) -> List[str]:
-    return [_.strip() for _ in items if _.strip()]
+def _filter(items: Optional[List[str]]) -> List[str]:
+    return [_.strip() for _ in (items or []) if _.strip()]
 
 
 def repair_wheel(wheel_path: str, abis: List[str], lib_sdir: str, out_dir: str,

--- a/auditwheel/repair.py
+++ b/auditwheel/repair.py
@@ -28,13 +28,13 @@ WHEEL_INFO_RE = re.compile(
     re.VERBOSE).match
 
 
-def _is_in_list(soname : str, l: Optional[List[str]]) -> str:
-    for item in l:
+def _is_in_list(soname: str, items: Optional[List[str]]) -> str:
+    for item in items:
         if item in soname:
             return item
 
 
-def _filter(l : List[str]) -> List[str]:
+def _filter(l: List[str]) -> List[str]:
     return [_.strip() for _ in l if _.strip()]
 
 
@@ -88,14 +88,15 @@ def repair_wheel(wheel_path: str, abis: List[str], lib_sdir: str, out_dir: str,
                 # exhaustive include list
                 if include and not _is_in_list(soname, include):
                     logger.debug(
-                        f'Excluding {soname} which is not in exhaustive include list'
-                        f' `{", ".join(include)}`)')
+                        f'Excluding {soname} which is not in exhaustive '
+                        f'include list `{", ".join(include)}`)')
                     continue
 
                 # exclude some libraries
                 exc = _is_in_list(soname, exclude)
                 if exc:
-                    logger.info(f'Excluding {soname} (matched exclude string `{exc}`)')
+                    logger.info(
+                        f'Excluding {soname} (match exclude string `{exc}`)')
                     continue
 
                 new_soname, new_path = copylib(src_path, dest_dir, patcher)


### PR DESCRIPTION
This is a quick fix to solve an issue I have with my project and for which auditwheel seemed to help. I don't know if this approach is suitable to other users of auditwheel.

I develop a C graphics library ([datoviz](https://github.com/datoviz/datoviz/)) that depends on Vulkan and comes with Cython bindings. [I'm trying to build a pip wheel](https://github.com/datoviz/datoviz/issues/13) for Linux (at least Ubuntu 20.04, that would be a start).

1. As a first step, I compile the C project and get a `libdatoviz.so` shared library. 
2. Then, I build the Cython library, which has a dynamic dependency to libdatoviz.
3. I'd like to bundle both the Cython extension module, and libdatoviz, in the same wheel.
4. I tried to use `auditwheel repair`. It included dozens of other dependencies in the wheel, including libvulkan and many graphics-related dependent libraries. The compiled wheel installs properly, but it doesn't work properly (there are issues related to windowing, GPU access, etc). Related: https://github.com/pypa/auditwheel/issues/241
5. I made some changes to auditwheel (this pull request) to exclude libvulkan and a few other libraries. Some issues were fixed, but not others.
6. As another approach, I tried to bundle *just* libdatoviz, and no other library in the wheel. That seems to work, at least on my computer. Chances are that the wheel may not work on other Linux-based operating systems though.

Any help would be appreciated, regarding either this pull request, and/or a way to solve the issue I'm facing. Thanks!
