### PR TITLE
Add support for musllinux

### DIFF
--- a/auditwheel/error.py
+++ b/auditwheel/error.py
@@ -1,0 +1,6 @@
+class AuditwheelException(Exception):
+    pass
+
+
+class InvalidLibc(AuditwheelException):
+    pass

--- a/auditwheel/libc.py
+++ b/auditwheel/libc.py
@@ -1,0 +1,23 @@
+import logging
+from enum import IntEnum
+
+from .error import InvalidLibc
+from .musllinux import find_musl_libc
+
+
+logger = logging.getLogger(__name__)
+
+
+class Libc(IntEnum):
+    GLIBC = 1,
+    MUSL = 2,
+
+
+def get_libc() -> Libc:
+    try:
+        find_musl_libc()
+        logger.debug("Detected musl libc")
+        return Libc.MUSL
+    except InvalidLibc:
+        logger.debug("Falling back to GNU libc")
+        return Libc.GLIBC

--- a/auditwheel/musllinux.py
+++ b/auditwheel/musllinux.py
@@ -1,0 +1,60 @@
+import logging
+import pathlib
+import subprocess
+import re
+from typing import NamedTuple
+
+from auditwheel.error import InvalidLibc
+
+LOG = logging.getLogger(__name__)
+
+
+class MuslVersion(NamedTuple):
+    major: int
+    minor: int
+    patch: int
+
+
+def find_musl_libc() -> pathlib.Path:
+    try:
+        ldd = subprocess.check_output(["ldd", "/bin/ls"], errors='strict')
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        LOG.error("Failed to determine libc version", exc_info=True)
+        raise InvalidLibc
+
+    match = re.search(
+        r"libc\.musl-(?P<platform>\w+)\.so.1 "  # TODO drop the platform
+        r"=> (?P<path>[/\-\w.]+)",
+        ldd)
+
+    if not match:
+        raise InvalidLibc
+
+    return pathlib.Path(match.group("path"))
+
+
+def get_musl_version(ld_path: pathlib.Path) -> MuslVersion:
+    try:
+        ld = subprocess.run(
+            [ld_path],
+            check=False,
+            errors='strict',
+            stderr=subprocess.PIPE
+        ).stderr
+    except FileNotFoundError:
+        LOG.error("Failed to determine musl version", exc_info=True)
+        raise InvalidLibc
+
+    match = re.search(
+        r"Version "
+        r"(?P<major>\d+)."
+        r"(?P<minor>\d+)."
+        r"(?P<patch>\d+)",
+        ld)
+    if not match:
+        raise InvalidLibc
+
+    return MuslVersion(
+        int(match.group("major")),
+        int(match.group("minor")),
+        int(match.group("patch")))

--- a/auditwheel/policy/musllinux-policy.json
+++ b/auditwheel/policy/musllinux-policy.json
@@ -1,0 +1,48 @@
+[
+  {"name": "linux",
+   "aliases": [],
+   "priority": 0,
+   "symbol_versions": {},
+   "lib_whitelist": []
+  },
+  {"name": "musllinux_1_1",
+    "aliases": [],
+    "priority": 100,
+    "symbol_versions": {
+      "i686": {
+      },
+      "x86_64": {
+      },
+      "aarch64": {
+      },
+      "ppc64le": {
+      },
+      "s390x": {
+      },
+      "armv7l": {
+      }
+    },
+    "lib_whitelist": [
+      "libc.so"
+    ]},
+    {"name": "musllinux_1_2",
+    "aliases": [],
+    "priority": 90,
+    "symbol_versions": {
+      "i686": {
+      },
+      "x86_64": {
+      },
+      "aarch64": {
+      },
+      "ppc64le": {
+      },
+      "s390x": {
+      },
+      "armv7l": {
+      }
+    },
+    "lib_whitelist": [
+      "libc.so"
+    ]}
+]

--- a/tests/unit/test_musllinux.py
+++ b/tests/unit/test_musllinux.py
@@ -1,0 +1,49 @@
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from auditwheel.musllinux import find_musl_libc, get_musl_version
+from auditwheel.error import InvalidLibc
+
+
+@patch("auditwheel.musllinux.subprocess.check_output")
+def test_find_musllinux_no_ldd(check_output_mock):
+    check_output_mock.side_effect = FileNotFoundError()
+    with pytest.raises(InvalidLibc):
+        find_musl_libc()
+
+
+@patch("auditwheel.musllinux.subprocess.check_output")
+def test_find_musllinux_ldd_error(check_output_mock):
+    check_output_mock.side_effect = subprocess.CalledProcessError(1, "ldd")
+    with pytest.raises(InvalidLibc):
+        find_musl_libc()
+
+
+@patch("auditwheel.musllinux.subprocess.check_output")
+def test_find_musllinux_not_found(check_output_mock):
+    check_output_mock.return_value = ""
+    with pytest.raises(InvalidLibc):
+        find_musl_libc()
+
+
+def test_get_musl_version_invalid_path():
+    with pytest.raises(InvalidLibc):
+        get_musl_version("/tmp/no/executable/here")
+
+
+@patch("auditwheel.musllinux.subprocess.run")
+def test_get_musl_version_invalid_version(run_mock):
+    run_mock.return_value = subprocess.CompletedProcess([], 1, None, "Version 1.1")
+    with pytest.raises(InvalidLibc):
+        get_musl_version("anything")
+
+
+@patch("auditwheel.musllinux.subprocess.run")
+def test_get_musl_version_valid_version(run_mock):
+    run_mock.return_value = subprocess.CompletedProcess([], 1, None, "Version 5.6.7")
+    version = get_musl_version("anything")
+    assert version.major == 5
+    assert version.minor == 6
+    assert version.patch == 7


### PR DESCRIPTION
This aims to modify less things than #313 at first to ease the review.
Once there are sufficient tests, the added complexity of #313 might be something to look into as it might be a good step forward to cross-repairing/cross-checking wheels.

@lkollar, thanks for the work in #313 (and in manylinux). What do you think of doing this in 2 steps as mentioned above?
1. add support for musllinux without extensively modifying the code base for manylinux
2. once we can test everything properly, refactor policy loading/management
