### PR TITLE
Don't installs self in tox deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@ skipsdist = True
 envlist = py36,py37,py38,py39,lint,cov
 
 [testenv]
-deps = .
-       -r{toxinidir}/test-requirements.txt
+deps = -r{toxinidir}/test-requirements.txt
 commands =  pytest --doctest-modules auditwheel tests []
 
 [testenv:lint]


### PR DESCRIPTION
Tox already does that by default.

In Fedora, when we build RPM packages,
we use a tox plugin that installs the test requirements from RPMs.
It does not know how to install the package we are building.