### PR TITLE
chore: add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Conversion to black code style
+aa52a60c59cd0e703f836d7fc88eae992645e760


### PR DESCRIPTION
This file is used as a convention for commits to be ignored by bulk code changes.
commit aa52a60c59cd0e703f836d7fc88eae992645e760 is such a commit (conversion to black code style).
see https://github.com/pypa/auditwheel/pull/329#pullrequestreview-744678624 /  https://www.moxio.com/blog/43/ignoring-bulk-change-commits-with-git-blame