### PR TITLE
fix: build warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = auditwheel
-home-page = https://github.com/pypa/auditwheel
+home_page = https://github.com/pypa/auditwheel
 license = MIT
 author = Robert T. McGibbon
-author-email = rmcgibbo@gmail.com
+author_email = rmcgibbo@gmail.com
 summary = Cross-distribution Linux wheels
-description-file = README.rst
+description_file = README.rst
 long_description_content_type = text/x-rst
 python_requires = >=3.6
 classifier =


### PR DESCRIPTION
Fix setuptools warnings seen during builds (deprecation notices)