### PR TITLE
fix: SDist includes files it shouldn't include

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,12 @@
 include README.rst
 include LICENSE
+
+exclude .coveragerc
+exclude .gitignore
+exclude .pre-commit-config.yaml
+exclude .travis.yml
+exclude noxfile.py
+
+prune .github
+prune scripts
+prune tests


### PR DESCRIPTION
Add exclusion for files that are not needed for the SDist