### PR TITLE
Add support for SOURCE_DATE_EPOCH

### DIFF
--- a/src/auditwheel/wheeltools.py
+++ b/src/auditwheel/wheeltools.py
@@ -9,6 +9,7 @@ import hashlib
 import logging
 import os
 from base64 import urlsafe_b64encode
+from datetime import datetime, timezone
 from itertools import product
 from os.path import abspath, basename, dirname, exists
 from os.path import join as pjoin
@@ -127,7 +128,11 @@ class InWheel(InTemporaryDirectory):
     ) -> None:
         if self.out_wheel is not None:
             rewrite_record(self.name)
-            dir2zip(self.name, self.out_wheel)
+            date_time = None
+            timestamp = os.environ.get("SOURCE_DATE_EPOCH")
+            if timestamp:
+                date_time = datetime.fromtimestamp(int(timestamp), tz=timezone.utc)
+            dir2zip(self.name, self.out_wheel, date_time)
         return super().__exit__(exc, value, tb)
 
 

--- a/tests/integration/test_bundled_wheels.py
+++ b/tests/integration/test_bundled_wheels.py
@@ -1,8 +1,16 @@
 import platform
+import subprocess
+import sys
+import zipfile
+from argparse import Namespace
+from datetime import datetime, timezone
 from pathlib import Path
+from unittest import mock
+from unittest.mock import Mock
 
 import pytest
 
+from auditwheel import main_repair
 from auditwheel.wheel_abi import analyze_wheel_abi
 
 HERE = Path(__file__).parent.resolve()
@@ -30,3 +38,49 @@ def test_analyze_wheel_abi_pyfpe():
     assert (
         winfo.pyfpe_tag == "linux_x86_64"
     )  # but for having the pyfpe reference, it gets just linux
+
+
+@pytest.mark.skipif(platform.machine() != "x86_64", reason="only checked on x86_64")
+def test_wheel_source_date_epoch(tmp_path, monkeypatch):
+    wheel_build_path = tmp_path / "wheel"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            "--no-deps",
+            "-w",
+            wheel_build_path,
+            HERE / "sample_extension",
+        ],
+        check=True,
+    )
+
+    wheel_path, *_ = list(wheel_build_path.glob("*.whl"))
+    wheel_output_path = tmp_path / "out"
+    args = Namespace(
+        LIB_SDIR=".libs",
+        ONLY_PLAT=False,
+        PLAT="manylinux_2_5_x86_64",
+        STRIP=False,
+        UPDATE_TAGS=True,
+        WHEEL_DIR=str(wheel_output_path),
+        WHEEL_FILE=str(wheel_path),
+        cmd="repair",
+        func=Mock(),
+        prog="auditwheel",
+        verbose=1,
+    )
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "650203200")
+    # patchelf might not be available as we aren't running in a manylinux container
+    # here. We don't need need it in this test, so just patch it.
+    with mock.patch("auditwheel.patcher._verify_patchelf"):
+        main_repair.execute(args, Mock())
+
+    output_wheel, *_ = list(wheel_output_path.glob("*.whl"))
+    with zipfile.ZipFile(output_wheel) as wheel_file:
+        for file in wheel_file.infolist():
+            assert (
+                datetime(*file.date_time, tzinfo=timezone.utc).timestamp() == 650203200
+            )


### PR DESCRIPTION
Setting `SOURCE_DATE_EPOCH` in the environment will set the time stamps
of all files and directories in the produced wheels to the specified
value.

Closes: #346 