### PR TITLE
fix: building from a github archive fails

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,12 @@
 include README.rst
 include LICENSE
+include CHANGELOG.md
+include src/auditwheel/policy/*.json
+include src/auditwheel/_vendor/wheel/LICENSE.txt
 
 exclude .coveragerc
 exclude .gitignore
+exclude .git-blame-ignore-revs
 exclude .pre-commit-config.yaml
 exclude .travis.yml
 exclude noxfile.py


### PR DESCRIPTION
setuptools_scm includes some files by default that are not included when building from a github archive. Include them manually to produce the same build.

Fixes #321 