### PR TITLE
Allow setuptools_scm 6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
We have setuptools_scm 6.0 in Fedora 35 and I've tried to build auditwheel with it -- it worked.

I am not entirely sure why 6.2 was used here, maybe just "to be safe"... ?