### PR TITLE
Add --exclude option to auditwheel repair

### DIFF
--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -89,6 +89,14 @@ wheel will abort processing of subsequent wheels.
         default=False,
     )
     p.add_argument(
+        "--exclude",
+        dest="EXCLUDE",
+        help="Exclude SONAME from grafting into the resulting wheel "
+        "(can be specified multiple times)",
+        action="append",
+        default=[],
+    )
+    p.add_argument(
         "--only-plat",
         dest="ONLY_PLAT",
         action="store_true",
@@ -169,6 +177,7 @@ def execute(args, p):
             out_dir=args.WHEEL_DIR,
             update_tags=args.UPDATE_TAGS,
             patcher=patcher,
+            exclude=args.EXCLUDE,
             strip=args.STRIP,
         )
 

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -37,6 +37,7 @@ def repair_wheel(
     out_dir: str,
     update_tags: bool,
     patcher: ElfPatcher,
+    exclude: List[str],
     strip: bool = False,
 ) -> Optional[str]:
 
@@ -70,6 +71,11 @@ def repair_wheel(
             ext_libs = v[abis[0]]["libs"]  # type: Dict[str, str]
             replacements = []  # type: List[Tuple[str, str]]
             for soname, src_path in ext_libs.items():
+
+                if soname in exclude:
+                    logger.info(f"Excluding {soname}")
+                    continue
+
                 if src_path is None:
                     raise ValueError(
                         (

--- a/tests/integration/test_bundled_wheels.py
+++ b/tests/integration/test_bundled_wheels.py
@@ -67,6 +67,7 @@ def test_wheel_source_date_epoch(tmp_path, monkeypatch):
         UPDATE_TAGS=True,
         WHEEL_DIR=str(wheel_output_path),
         WHEEL_FILE=[str(wheel_path)],
+        EXCLUDE=[],
         cmd="repair",
         func=Mock(),
         prog="auditwheel",

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -200,6 +200,45 @@ def assert_show_output(manylinux_ctr, wheel, expected_tag, strict):
         assert actual_glibc <= expected_glibc
 
 
+def build_numpy(container, policy, output_dir):
+    """Helper to build numpy from source using the specified container, into
+    output_dir."""
+
+    if policy.startswith("musllinux_"):
+        docker_exec(container, "apk add openblas-dev")
+    elif policy.startswith("manylinux_2_24_"):
+        docker_exec(container, "apt-get update")
+        docker_exec(
+            container, "apt-get install -y --no-install-recommends libatlas-dev"
+        )
+    else:
+        docker_exec(container, "yum install -y atlas atlas-devel")
+
+    if op.exists(op.join(WHEEL_CACHE_FOLDER, policy, ORIGINAL_NUMPY_WHEEL)):
+        # If numpy has already been built and put in cache, let's reuse this.
+        shutil.copy2(
+            op.join(WHEEL_CACHE_FOLDER, policy, ORIGINAL_NUMPY_WHEEL),
+            op.join(output_dir, ORIGINAL_NUMPY_WHEEL),
+        )
+    else:
+        # otherwise build the original linux_x86_64 numpy wheel from source
+        # and put the result in the cache folder to speed-up future build.
+        # This part of the build is independent of the auditwheel code-base
+        # so it's safe to put it in cache.
+
+        docker_exec(
+            container,
+            f"pip wheel -w /io --no-binary=:all: numpy=={NUMPY_VERSION}",
+        )
+        os.makedirs(op.join(WHEEL_CACHE_FOLDER, policy), exist_ok=True)
+        shutil.copy2(
+            op.join(output_dir, ORIGINAL_NUMPY_WHEEL),
+            op.join(WHEEL_CACHE_FOLDER, policy, ORIGINAL_NUMPY_WHEEL),
+        )
+    orig_wheel, *_ = os.listdir(output_dir)
+    return orig_wheel
+
+
 class Anylinux:
     @pytest.fixture()
     def io_folder(self, tmp_path):
@@ -230,43 +269,12 @@ class Anylinux:
         self, any_manylinux_container, docker_python, io_folder
     ):
         # Integration test: repair numpy built from scratch
+        policy, tag, manylinux_ctr = any_manylinux_container
 
         # First build numpy from source as a naive linux wheel that is tied
         # to system libraries (atlas, libgfortran...)
-        policy, tag, manylinux_ctr = any_manylinux_container
-        if policy.startswith("musllinux_"):
-            docker_exec(manylinux_ctr, "apk add openblas-dev")
-        elif policy.startswith("manylinux_2_24_"):
-            docker_exec(manylinux_ctr, "apt-get update")
-            docker_exec(
-                manylinux_ctr, "apt-get install -y --no-install-recommends libatlas-dev"
-            )
-        else:
-            docker_exec(manylinux_ctr, "yum install -y atlas atlas-devel")
-
-        if op.exists(op.join(WHEEL_CACHE_FOLDER, policy, ORIGINAL_NUMPY_WHEEL)):
-            # If numpy has already been built and put in cache, let's reuse this.
-            shutil.copy2(
-                op.join(WHEEL_CACHE_FOLDER, policy, ORIGINAL_NUMPY_WHEEL),
-                op.join(io_folder, ORIGINAL_NUMPY_WHEEL),
-            )
-        else:
-            # otherwise build the original linux_x86_64 numpy wheel from source
-            # and put the result in the cache folder to speed-up future build.
-            # This part of the build is independent of the auditwheel code-base
-            # so it's safe to put it in cache.
-            docker_exec(
-                manylinux_ctr,
-                f"pip wheel -w /io --no-binary=:all: numpy=={NUMPY_VERSION}",
-            )
-            os.makedirs(op.join(WHEEL_CACHE_FOLDER, policy), exist_ok=True)
-            shutil.copy2(
-                op.join(io_folder, ORIGINAL_NUMPY_WHEEL),
-                op.join(WHEEL_CACHE_FOLDER, policy, ORIGINAL_NUMPY_WHEEL),
-            )
-        filenames = os.listdir(io_folder)
-        assert filenames == [ORIGINAL_NUMPY_WHEEL]
-        orig_wheel = filenames[0]
+        orig_wheel = build_numpy(manylinux_ctr, policy, io_folder)
+        assert orig_wheel == ORIGINAL_NUMPY_WHEEL
         assert "manylinux" not in orig_wheel
 
         # Repair the wheel using the manylinux container


### PR DESCRIPTION
This is a follow-up of #310 by @rossant, only keeping the `exclude` option as suggested by @mayeut

Closes #76
Closes #241
Closes #310
Fixes #391

Original PR description:

----

This is a quick fix to solve an issue I have with my project and for which auditwheel seemed to help. I don't know if this approach is suitable to other users of auditwheel.

I develop a C graphics library ([datoviz](https://github.com/datoviz/datoviz/)) that depends on Vulkan and comes with Cython bindings. https://github.com/datoviz/datoviz/issues/13 for Linux (at least Ubuntu 20.04, that would be a start).

1. As a first step, I compile the C project and get a libdatoviz.so shared library.
2. Then, I build the Cython library, which has a dynamic dependency to libdatoviz.
3. I'd like to bundle both the Cython extension module, and libdatoviz, in the same wheel.
4. I tried to use auditwheel repair. It included dozens of other dependencies in the wheel, including libvulkan and many graphics-related dependent libraries. The compiled wheel installs properly, but it doesn't work properly (there are issues related to windowing, GPU access, etc). Related: https://github.com/pypa/auditwheel/issues/241[](https://github.com/rossant)
5. I made some changes to auditwheel (this pull request) to exclude libvulkan and a few other libraries. Some issues were fixed, but not others.
6. As another approach, I tried to bundle just libdatoviz, and no other library in the wheel. That seems to work, at least on my computer. Chances are that the wheel may not work on other Linux-based operating systems though.
Any help would be appreciated, regarding either this pull request, and/or a way to solve the issue I'm facing. Thanks!