### PR TITLE
ci: use GHA concurrency group

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     name: Pre-commit checks (Black, Flake8, MyPy, ...)


### PR DESCRIPTION
cancel in progress PR builds if there's a new commit on the PR to free up CI resources.