### PR TITLE
Corrected link syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,8 +121,8 @@ Released Jul. 1, 2020
 
 ### User-facing changes
 - [FEATURE] Ensure that system-copied libraries are writable before running patchelf
-  ([https://github.com/pypa/auditwheel/pull/237](#237))
-- [FEATURE] Preserve RPATH in extension modules ([https://github.com/pypa/auditwheel/pull/245](#245))
+  ([#237](https://github.com/pypa/auditwheel/pull/237))
+- [FEATURE] Preserve RPATH in extension modules ([#245](https://github.com/pypa/auditwheel/pull/245))
 
 ## 3.1.1
 


### PR DESCRIPTION
At https://github.com/pypa/auditwheel/blob/main/CHANGELOG.md#320, the links within "User-facing changes" are incorrectly formatted.

For example, the first one should be a link to `https://github.com/pypa/auditwheel/pull/237`, displaying simply as `#237`, but instead it's the opposite - a link to `#237` displaying as `https://github.com/pypa/auditwheel/pull/237`