### PR TITLE
feature: allow specifying additional library paths (fixes: #373)

### DIFF
--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 from os.path import abspath, basename, exists, isfile
 
 from auditwheel.patcher import Patchelf
@@ -92,6 +93,12 @@ below.
         help="Do not check for higher policy compatibility",
         default=False,
     )
+    p.add_argument(
+        "--add-path",
+        dest="PATHS",
+        default="",
+        help=f"Additional path(s) to search for libraries, {os.pathsep!r}-delimited",
+    )
     p.set_defaults(func=execute)
 
 
@@ -105,6 +112,12 @@ def execute(args, p):
         p.error("cannot access %s. No such file" % args.WHEEL_FILE)
 
     logger.info("Repairing %s", basename(args.WHEEL_FILE))
+
+    if args.PATHS:
+        library_path = args.PATHS
+        if "LD_LIBRARY_PATH" in os.environ:
+            library_path += os.pathsep + os.environ["LD_LIBRARY_PATH"]
+        os.environ["LD_LIBRARY_PATH"] = library_path
 
     if not exists(args.WHEEL_DIR):
         os.makedirs(args.WHEEL_DIR)

--- a/tests/integration/test_bundled_wheels.py
+++ b/tests/integration/test_bundled_wheels.py
@@ -62,6 +62,7 @@ def test_wheel_source_date_epoch(tmp_path, monkeypatch):
     args = Namespace(
         LIB_SDIR=".libs",
         ONLY_PLAT=False,
+        PATHS="",
         PLAT="manylinux_2_5_x86_64",
         STRIP=False,
         UPDATE_TAGS=True,


### PR DESCRIPTION
Add new --add-path option to auditwheel repair to search for libraries
in additional directories. This avoid having to manipulate
LD_LIBRARY_PATH in the calling process (e.g. cibuildwheel), as this can
have undesirable side-effects.

The name of the option is chosen to match the one provided by
`delvewheel` on Windows.

fixes #373 