### PR TITLE
Update 'replace_needed' to reduce total calls to 'patchelf'

### DIFF
--- a/src/auditwheel/patcher.py
+++ b/src/auditwheel/patcher.py
@@ -1,10 +1,17 @@
 import re
 from distutils.spawn import find_executable
+from itertools import chain
 from subprocess import CalledProcessError, check_call, check_output
+from typing import Iterable, Tuple
 
 
 class ElfPatcher:
     def replace_needed(self, file_name: str, so_name: str, new_so_name: str) -> None:
+        raise NotImplementedError
+
+    def replace_needed_multiple(
+        self, file_name: str, so_name_pairs: Iterable[Tuple[str, str]]
+    ) -> None:
         raise NotImplementedError
 
     def set_soname(self, file_name: str, new_so_name: str) -> None:
@@ -43,6 +50,19 @@ class Patchelf(ElfPatcher):
 
     def replace_needed(self, file_name: str, so_name: str, new_so_name: str) -> None:
         check_call(["patchelf", "--replace-needed", so_name, new_so_name, file_name])
+
+    def replace_needed_multiple(
+        self, file_name: str, so_name_pairs: Iterable[Tuple[str, str]]
+    ) -> None:
+        check_call(
+            [
+                "patchelf",
+                *chain.from_iterable(
+                    ("--replace-needed", *pair) for pair in so_name_pairs
+                ),
+                file_name,
+            ]
+        )
 
     def set_soname(self, file_name: str, new_so_name: str) -> None:
         check_call(["patchelf", "--set-soname", new_so_name, file_name])

--- a/src/auditwheel/patcher.py
+++ b/src/auditwheel/patcher.py
@@ -2,16 +2,11 @@ import re
 from distutils.spawn import find_executable
 from itertools import chain
 from subprocess import CalledProcessError, check_call, check_output
-from typing import Iterable, Tuple
+from typing import Tuple
 
 
 class ElfPatcher:
-    def replace_needed(self, file_name: str, so_name: str, new_so_name: str) -> None:
-        raise NotImplementedError
-
-    def replace_needed_multiple(
-        self, file_name: str, so_name_pairs: Iterable[Tuple[str, str]]
-    ) -> None:
+    def replace_needed(self, file_name: str, *old_new_pairs: Tuple[str, str]) -> None:
         raise NotImplementedError
 
     def set_soname(self, file_name: str, new_so_name: str) -> None:
@@ -48,17 +43,12 @@ class Patchelf(ElfPatcher):
     def __init__(self) -> None:
         _verify_patchelf()
 
-    def replace_needed(self, file_name: str, so_name: str, new_so_name: str) -> None:
-        check_call(["patchelf", "--replace-needed", so_name, new_so_name, file_name])
-
-    def replace_needed_multiple(
-        self, file_name: str, so_name_pairs: Iterable[Tuple[str, str]]
-    ) -> None:
+    def replace_needed(self, file_name: str, *old_new_pairs: Tuple[str, str]) -> None:
         check_call(
             [
                 "patchelf",
                 *chain.from_iterable(
-                    ("--replace-needed", *pair) for pair in so_name_pairs
+                    ("--replace-needed", *pair) for pair in old_new_pairs
                 ),
                 file_name,
             ]

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -83,7 +83,7 @@ def repair_wheel(
                 soname_map[soname] = (new_soname, new_path)
                 replacements.append((soname, new_soname))
             if replacements:
-                patcher.replace_needed_multiple(fn, replacements)
+                patcher.replace_needed(fn, *replacements)
 
             if len(ext_libs) > 0:
                 new_rpath = os.path.relpath(dest_dir, os.path.dirname(fn))
@@ -101,7 +101,7 @@ def repair_wheel(
                 if n in soname_map:
                     replacements.append((n, soname_map[n][0]))
             if replacements:
-                patcher.replace_needed_multiple(path, replacements)
+                patcher.replace_needed(path, *replacements)
 
         if update_tags:
             ctx.out_wheel = add_platforms(ctx, abis, get_replace_platforms(abis[0]))

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -67,8 +67,8 @@ def repair_wheel(
         # here, fn is a path to a python extension library in
         # the wheel, and v['libs'] contains its required libs
         for fn, v in external_refs_by_fn.items():
-
             ext_libs = v[abis[0]]["libs"]  # type: Dict[str, str]
+            replacements = []  # type: List[Tuple[str, str]]
             for soname, src_path in ext_libs.items():
                 if src_path is None:
                     raise ValueError(
@@ -81,7 +81,9 @@ def repair_wheel(
 
                 new_soname, new_path = copylib(src_path, dest_dir, patcher)
                 soname_map[soname] = (new_soname, new_path)
-                patcher.replace_needed(fn, soname, new_soname)
+                replacements.append((soname, new_soname))
+            if replacements:
+                patcher.replace_needed_multiple(fn, replacements)
 
             if len(ext_libs) > 0:
                 new_rpath = os.path.relpath(dest_dir, os.path.dirname(fn))
@@ -94,9 +96,12 @@ def repair_wheel(
         # name of the other.
         for old_soname, (new_soname, path) in soname_map.items():
             needed = elf_read_dt_needed(path)
+            replacements = []
             for n in needed:
                 if n in soname_map:
-                    patcher.replace_needed(path, n, soname_map[n][0])
+                    replacements.append((n, soname_map[n][0]))
+            if replacements:
+                patcher.replace_needed_multiple(path, replacements)
 
         if update_tags:
             ctx.out_wheel = add_platforms(ctx, abis, get_replace_platforms(abis[0]))

--- a/tests/unit/test_elfpatcher.py
+++ b/tests/unit/test_elfpatcher.py
@@ -41,24 +41,24 @@ def test_patchelf_version_check_fail(check_output, version):
 class TestPatchElf:
     """ "Validate that patchelf is invoked with the correct arguments."""
 
-    def test_replace_needed(self, check_call, _0, _1):
+    def test_replace_needed_one(self, check_call, _0, _1):
         patcher = Patchelf()
         filename = "test.so"
         soname_old = "TEST_OLD"
         soname_new = "TEST_NEW"
-        patcher.replace_needed(filename, soname_old, soname_new)
+        patcher.replace_needed(filename, (soname_old, soname_new))
         check_call.assert_called_once_with(
             ["patchelf", "--replace-needed", soname_old, soname_new, filename]
         )
 
-    def test_replace_needed_multiple(self, check_call, _0, _1):
+    def test_replace_needed_multple(self, check_call, _0, _1):
         patcher = Patchelf()
         filename = "test.so"
         replacements = [
             ("TEST_OLD1", "TEST_NEW1"),
             ("TEST_OLD2", "TEST_NEW2"),
         ]
-        patcher.replace_needed_multiple(filename, replacements)
+        patcher.replace_needed(filename, *replacements)
         check_call.assert_called_once_with(
             [
                 "patchelf",

--- a/tests/unit/test_elfpatcher.py
+++ b/tests/unit/test_elfpatcher.py
@@ -51,6 +51,25 @@ class TestPatchElf:
             ["patchelf", "--replace-needed", soname_old, soname_new, filename]
         )
 
+    def test_replace_needed_multiple(self, check_call, _0, _1):
+        patcher = Patchelf()
+        filename = "test.so"
+        replacements = [
+            ("TEST_OLD1", "TEST_NEW1"),
+            ("TEST_OLD2", "TEST_NEW2"),
+        ]
+        patcher.replace_needed_multiple(filename, replacements)
+        check_call.assert_called_once_with(
+            [
+                "patchelf",
+                "--replace-needed",
+                *replacements[0],
+                "--replace-needed",
+                *replacements[1],
+                filename,
+            ]
+        )
+
     def test_set_soname(self, check_call, _0, _1):
         patcher = Patchelf()
         filename = "test.so"


### PR DESCRIPTION
This changes `auditwheel repair` to use the multiple-occurrences invocation of `patchelf --replace-needed` (i.e. `patchelf --replace-needed old_1.so new_1.so --replace-needed old_2.so new_2.so filename.so`) instead of calling `patchelf` multiple times. I observed ~~two~~ three benefits to this:

1. Each call to `patchelf` seems to increase the size of the resulting binary. Though in my instance the compressed size was comparable, the inflated size difference was significant (see below for a comparison). This is meaningful when wheels are distributed installed e.g. as part of a Docker image.
2. Reducing the number of calls to `patchelf` also seems to result in faster wheel repair.
3. Without this change, `auditwheel repair --strip ...` would produce a broken wheel that gave an `ELF load command address/offset not properly aligned` error on import. With this change, `--strip` seems to work as expected.

This may be more of a workaround for issues with `patchelf` (see https://github.com/NixOS/patchelf/issues/370), but I'm not familiar with the internal workings of that program. 

Thanks for considering this change! I welcome any feedback as this is my first time really digging into packaging. I would be very interested to see if this improvement holds up generally across many different packages.

### Sample inflated wheel size comparison
(sorry for the very verbose output)
#### Proposed change
Note the total inflated size is reduced by ~5x in this example.
```shell
[root@2b2bee6ed3f3 wheelhouse]# unzip -l wheelhouse-new/antspyx-0.3.2+hri.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
Archive:  wheelhouse-new/antspyx-0.3.2+hri.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  04-13-2022 15:57   antspyx.libs/
        0  04-13-2022 15:57   antspyx-0.3.2+hri.0.dist-info/
        0  04-13-2022 15:57   ants/
   526632  04-13-2022 15:57   antspyx.libs/libitktiff-5-676c3f9f.3.so.1
   404096  04-13-2022 15:57   antspyx.libs/libitkgdcmopenjp2-5-21100300.3.so.1
    35568  04-13-2022 15:57   antspyx.libs/libITKRegistrationMethodsv4-5-5768b011.3.so.1
   148456  04-13-2022 15:57   antspyx.libs/libITKIOTransformMatlab-5-2e6a88da.3.so.1
   113144  04-13-2022 15:57   antspyx.libs/libITKIOLSM-5-bd6bdcb3.3.so.1
   584016  04-13-2022 15:57   antspyx.libs/libitksys-5-9387fd6e.3.so.1
   706216  04-13-2022 15:57   antspyx.libs/libITKOptimizers-5-825fe76b.3.so.1
    44304  04-13-2022 15:57   antspyx.libs/libITKPolynomials-5-7acf0399.3.so.1
   499120  04-13-2022 15:57   antspyx.libs/libitkminc2-5-b55b2e59.3.so.1
   141064  04-13-2022 15:57   antspyx.libs/libITKIOMeshBYU-5-af5ee9b7.3.so.1
  2838160  04-13-2022 15:57   antspyx.libs/libitkgdcmDICT-5-602b02a3.3.so.1
    39184  04-13-2022 15:57   antspyx.libs/libITKMesh-5-33e82eca.3.so.1
    79512  04-13-2022 15:57   antspyx.libs/libITKIOCSV-5-5d35fb7f.3.so.1
   196832  04-13-2022 15:57   antspyx.libs/libITKgiftiio-5-34e6384e.3.so.1
   484544  04-13-2022 15:57   antspyx.libs/libITKSpatialObjects-5-e8152a73.3.so.1
  1442880  04-13-2022 15:57   antspyx.libs/libitkvnl_algo-5-e6ce72e1.3.so.1
    17216  04-13-2022 15:57   antspyx.libs/libITKSmoothing-5-141064e8.3.so.1
    41456  04-13-2022 15:57   antspyx.libs/libitkNetlibSlatec-5-e614f7e3.3.so.1
   313424  04-13-2022 15:57   antspyx.libs/libitkjpeg-5-3bbeee3a.3.so.1
   464264  04-13-2022 15:57   antspyx.libs/libITKIOTransformBase-5-121f2389.3.so.1
    21512  04-13-2022 15:57   antspyx.libs/libITKDenoising-5-00f91b7d.3.so.1
   839880  04-13-2022 15:57   antspyx.libs/libITKIOMeshVTK-5-09a0899c.3.so.1
  1260712  04-13-2022 15:57   antspyx.libs/libitkgdcmDSED-5-e6ec6a7b.3.so.1
  4094472  04-13-2022 15:57   antspyx.libs/libITKFFT-5-ea8e03b8.3.so.1
    25792  04-13-2022 15:57   antspyx.libs/libITKRegionGrowing-5-c45e7396.3.so.1
    62784  04-13-2022 15:57   antspyx.libs/libITKWatersheds-5-29b97520.3.so.1
   200944  04-13-2022 15:57   antspyx.libs/libITKIOXML-5-3a1e8b08.3.so.1
   111224  04-13-2022 15:57   antspyx.libs/libITKIOMeshBase-5-6fec2de6.3.so.1
   105768  04-13-2022 15:57   antspyx.libs/libITKKLMRegionGrowing-5-e9d012cc.3.so.1
   121408  04-13-2022 15:57   antspyx.libs/libITKIOGIPL-5-b7f79d5a.3.so.1
  5013840  04-13-2022 15:57   antspyx.libs/libitkhdf5-shared-5-cfd06ae4.3.so.1
    21656  04-13-2022 15:57   antspyx.libs/libitkvcl-5-bb700565.3.so.1
   340272  04-13-2022 15:57   antspyx.libs/libITKNrrdIO-5-ca003690.3.so.1
    25992  04-13-2022 15:57   antspyx.libs/libITKPDEDeformableRegistration-5-551d8f54.3.so.1
    25792  04-13-2022 15:57   antspyx.libs/libITKMathematicalMorphology-5-7a3f72c7.3.so.1
   207552  04-13-2022 15:57   antspyx.libs/libITKIOMeshGifti-5-69409b91.3.so.1
    29888  04-13-2022 15:57   antspyx.libs/libITKQuadEdgeMeshFiltering-5-67af6c32.3.so.1
    25120  04-13-2022 15:57   antspyx.libs/libITKVNLInstantiation-5-9c5f799d.3.so.1
   223048  04-13-2022 15:57   antspyx.libs/libITKIONIFTI-5-4f0ac868.3.so.1
   246520  04-13-2022 15:57   antspyx.libs/libitkgdcmjpeg8-5-c066f1af.3.so.1
   177248  04-13-2022 15:57   antspyx.libs/libITKIOIPL-5-b8ad9712.3.so.1
   113032  04-13-2022 15:57   antspyx.libs/libITKIOSiemens-5-228a2bc0.3.so.1
   201832  04-13-2022 15:57   antspyx.libs/libITKIOMeshFreeSurfer-5-4e372563.3.so.1
   109576  04-13-2022 15:57   antspyx.libs/libitkgdcmCommon-5-49c20d24.3.so.1
   238448  04-13-2022 15:57   antspyx.libs/libitkgdcmjpeg12-5-4d714595.3.so.1
   977144  04-13-2022 15:57   antspyx.libs/libITKMetaIO-5-8bf156dd.3.so.1
   237648  04-13-2022 15:57   antspyx.libs/libitkopenjpeg-5-1a34806f.3.so.1
   130064  04-13-2022 15:57   antspyx.libs/libITKIOJPEG-5-d06d0bfe.3.so.1
   184336  04-13-2022 15:57   antspyx.libs/libITKIOJPEG2000-5-42f282e4.3.so.1
    25848  04-13-2022 15:57   antspyx.libs/libITKConvolution-5-091f396c.3.so.1
   178808  04-13-2022 15:57   antspyx.libs/libITKIOGE-5-6163aea1.3.so.1
    35472  04-13-2022 15:57   antspyx.libs/libITKQuadEdgeMesh-5-2c5b682d.3.so.1
   129808  04-13-2022 15:57   antspyx.libs/libITKIOBMP-5-9aaf95d2.3.so.1
    29128  04-13-2022 15:57   antspyx.libs/libITKznz-5-488075b2.3.so.1
   396384  04-13-2022 15:57   antspyx.libs/libITKIOHDF5-5-daaa54a0.3.so.1
   219816  04-13-2022 15:57   antspyx.libs/libITKIOMeta-5-7d3e013b.3.so.1
   121928  04-13-2022 15:57   antspyx.libs/libITKIOBioRad-5-d193602d.3.so.1
   177016  04-13-2022 15:57   antspyx.libs/libITKIONRRD-5-a59385d5.3.so.1
   187360  04-13-2022 15:57   antspyx.libs/libpng15-ce838cd1.so.15.13.0
   134448  04-13-2022 15:57   antspyx.libs/libITKIOStimulate-5-78e40c98.3.so.1
   224824  04-13-2022 15:57   antspyx.libs/libITKIOBruker-5-f2fcb35b.3.so.1
   325088  04-13-2022 15:57   antspyx.libs/libITKIOGDCM-5-989e05ac.3.so.1
   195536  04-13-2022 15:57   antspyx.libs/libITKIOMINC-5-c6454c1a.3.so.1
    25688  04-13-2022 15:57   antspyx.libs/libITKImageFeature-5-7b832af5.3.so.1
  2261536  04-13-2022 15:57   antspyx.libs/libITKCommon-5-77580bde.3.so.1
   624232  04-13-2022 15:57   antspyx.libs/libitkgdcmcharls-5-473d5561.3.so.1
   154120  04-13-2022 15:57   antspyx.libs/libitkzlib-5-8d51c88c.3.so.1.2.11.zlib-ng
   115752  04-13-2022 15:57   antspyx.libs/libitkgdcmIOD-5-870e3d40.3.so.1
    35352  04-13-2022 15:57   antspyx.libs/libITKBiasCorrection-5-47fce04b.3.so.1
   197008  04-13-2022 15:57   antspyx.libs/libITKIOTransformHDF5-5-7be9b192.3.so.1
    85864  04-13-2022 15:57   antspyx.libs/libitkdouble-conversion-5-61107de3.3.so.1
  7251088  04-13-2022 15:57   antspyx.libs/libITKTestKernel-5-748bf3ac.3.so.1
   225248  04-13-2022 15:57   antspyx.libs/libITKEXPAT-5-1151843b.3.so.1
    35168  04-13-2022 15:57   antspyx.libs/libITKTransform-5-dd17e93c.3.so.1
  9936768  04-13-2022 15:57   antspyx.libs/libITKTransformFactory-5-4de6fc0d.3.so.1
   311392  04-13-2022 15:57   antspyx.libs/libITKOptimizersv4-5-db98c968.3.so.1
   146824  04-13-2022 15:57   antspyx.libs/libitkMGHIO-5-8f2e6e10.3.so.1
 17373256  04-13-2022 15:57   antspyx.libs/libitkvnl-5-e8086a45.3.so.1
   182712  04-13-2022 15:57   antspyx.libs/libITKIOMRC-5-06d7de70.3.so.1
    25808  04-13-2022 15:57   antspyx.libs/libitkAdaptiveDenoising-5-294cf63d.3.so.1
    25976  04-13-2022 15:57   antspyx.libs/libITKDeformableMesh-5-8ad25a88.3.so.1
    25800  04-13-2022 15:57   antspyx.libs/libITKMarkovRandomFieldsClassifiers-5-cc3df7c8.3.so.1
   111176  04-13-2022 15:57   antspyx.libs/libITKPath-5-5fccea1d.3.so.1
    21504  04-13-2022 15:57   antspyx.libs/libITKFastMarching-5-fd67f682.3.so.1
   170776  04-13-2022 15:57   antspyx.libs/libITKniftiio-5-a1167cd6.3.so.1
    21264  04-13-2022 15:57   antspyx.libs/libitkgdcmuuid-5-117fa7ed.3.so.1
   170232  04-13-2022 15:57   antspyx.libs/libITKIOTransformInsightLegacy-5-a76ca6b1.3.so.1
    33488  04-13-2022 15:57   antspyx.libs/libitklbfgs-5-3edcb43b.3.so.1
    17216  04-13-2022 15:57   antspyx.libs/libITKColormap-5-f97d9f44.3.so.1
   422624  04-13-2022 15:57   antspyx.libs/libITKIOSpatialObjects-5-4ceb105d.3.so.1
   197744  04-13-2022 15:57   antspyx.libs/libITKReview-5-1d7e8309.3.so.1
  1161040  04-13-2022 15:57   antspyx.libs/libitkv3p_netlib-5-4b54c378.3.so.1
    17256  04-13-2022 15:57   antspyx.libs/libITKDiffusionTensorImage-5-a34c123e.3.so.1
   216752  04-13-2022 15:57   antspyx.libs/libITKStatistics-5-a16b04cd.3.so.1
   170608  04-13-2022 15:57   antspyx.libs/libITKIOMeshOBJ-5-55a0b54c.3.so.1
   238448  04-13-2022 15:57   antspyx.libs/libitkgdcmjpeg16-5-2b4df9be.3.so.1
   188952  04-13-2022 15:57   antspyx.libs/libITKIOVTK-5-c91247dc.3.so.1
   138280  04-13-2022 15:57   antspyx.libs/libITKIOPNG-5-c368b6c6.3.so.1
   856720  04-13-2022 15:57   antspyx.libs/libitkhdf5_cpp-shared-5-25b86089.3.so.1
    30152  04-13-2022 15:57   antspyx.libs/libITKLabelMap-5-8820f3fa.3.so.1
   186840  04-13-2022 15:57   antspyx.libs/libITKIOMeshOFF-5-3fb02870.3.so.1
    90056  04-13-2022 15:57   antspyx.libs/libITKVTK-5-8f97fa3a.3.so.1
   236840  04-13-2022 15:57   antspyx.libs/libITKIOTIFF-5-d178402b.3.so.1
  2791864  04-13-2022 15:57   antspyx.libs/libitkgdcmMSFF-5-f7a8c9e7.3.so.1
   331792  04-13-2022 15:57   antspyx.libs/libITKIOImageBase-5-105668d8.3.so.1
    11357  04-13-2022 15:57   antspyx-0.3.2+hri.0.dist-info/LICENSE
        5  04-13-2022 15:57   antspyx-0.3.2+hri.0.dist-info/top_level.txt
     5836  04-13-2022 15:57   antspyx-0.3.2+hri.0.dist-info/METADATA
    26142  04-13-2022 15:57   antspyx-0.3.2+hri.0.dist-info/RECORD
      150  04-13-2022 15:57   antspyx-0.3.2+hri.0.dist-info/WHEEL
        0  04-13-2022 15:57   ants/learn/
        0  04-13-2022 15:57   ants/utils/
        0  04-13-2022 15:57   ants/lib/
        0  04-13-2022 15:57   ants/contrib/
        0  04-13-2022 15:57   ants/segmentation/
        0  04-13-2022 15:57   ants/viz/
        0  04-13-2022 15:57   ants/core/
        0  04-13-2022 15:57   ants/registration/
       28  04-13-2022 15:57   ants/version.py
      221  04-13-2022 15:57   ants/__init__.py
       29  04-13-2022 15:57   ants/learn/__init__.py
    13566  04-13-2022 15:57   ants/learn/decomposition.py
     1007  04-13-2022 15:57   ants/utils/hausdorff_distance.py
     2490  04-13-2022 15:57   ants/utils/label_image_centroids.py
     3400  04-13-2022 15:57   ants/utils/ndimage_to_list.py
     2321  04-13-2022 15:57   ants/utils/denoise_image.py
     4863  04-13-2022 15:57   ants/utils/impute.py
     2480  04-13-2022 15:57   ants/utils/smooth_image.py
     4161  04-13-2022 15:57   ants/utils/morphology.py
     2435  04-13-2022 15:57   ants/utils/ants_integrate_velocity_field.py
     1624  04-13-2022 15:57   ants/utils/histogram_match_image.py
     6473  04-13-2022 15:57   ants/utils/get_neighborhood.py
     1397  04-13-2022 15:57   ants/utils/image_to_cluster_images.py
     1023  04-13-2022 15:57   ants/utils/label_stats.py
     8235  04-13-2022 15:57   ants/utils/fit_bspline_object_to_scattered_data.py
     1162  04-13-2022 15:57   ants/utils/label_overlap_measures.py
     7974  04-13-2022 15:57   ants/utils/invariant_image_similarity.py
     2517  04-13-2022 15:57   ants/utils/channels.py
     1500  04-13-2022 15:57   ants/utils/get_centroids.py
     1903  04-13-2022 15:57   ants/utils/labels_to_matrix.py
     1572  04-13-2022 15:57   ants/utils/convert_nibabel.py
     1248  04-13-2022 15:57   ants/utils/__init__.py
     5923  04-13-2022 15:57   ants/utils/iMath.py
     8429  04-13-2022 15:57   ants/utils/fit_bspline_displacement_field.py
     1436  04-13-2022 15:57   ants/utils/label_clusters.py
     3976  04-13-2022 15:57   ants/utils/multi_label_morphology.py
     1875  04-13-2022 15:57   ants/utils/weingarten_image_curvature.py
      819  04-13-2022 15:57   ants/utils/slice_image.py
     2609  04-13-2022 15:57   ants/utils/get_mask.py
     1536  04-13-2022 15:57   ants/utils/mask_image.py
    13623  04-13-2022 15:57   ants/utils/quantile.py
     4392  04-13-2022 15:57   ants/utils/crop_image.py
     9863  04-13-2022 15:57   ants/utils/bias_correction.py
     2969  04-13-2022 15:57   ants/utils/get_ants_data.py
     2364  04-13-2022 15:57   ants/utils/process_args.py
     4171  04-13-2022 15:57   ants/utils/scalar_rgb_vector.py
     2500  04-13-2022 15:57   ants/utils/pad_image.py
     1609  04-13-2022 15:57   ants/utils/threshold_image.py
     3368  04-13-2022 15:57   ants/utils/simulate_displacement_field.py
     1716  04-13-2022 15:57   ants/utils/image_similarity.py
     1377  04-13-2022 15:57   ants/utils/mni2tal.py
     3211  04-13-2022 15:57   ants/utils/add_noise_to_image.py
  1603640  04-13-2022 15:57   ants/lib/antsImageAugment.cpython-37m-x86_64-linux-gnu.so
   517672  04-13-2022 15:57   ants/lib/reflectionMatrix.cpython-37m-x86_64-linux-gnu.so
   150192  04-13-2022 15:57   ants/lib/antsImageHeaderInfo.cpython-37m-x86_64-linux-gnu.so
  1742704  04-13-2022 15:57   ants/lib/antsJointFusion.cpython-37m-x86_64-linux-gnu.so
  1323576  04-13-2022 15:57   ants/lib/antsImage.cpython-37m-x86_64-linux-gnu.so
  2365376  04-13-2022 15:57   ants/lib/antsAffineInitializer.cpython-37m-x86_64-linux-gnu.so
  1548600  04-13-2022 15:57   ants/lib/simulateDisplacementField.cpython-37m-x86_64-linux-gnu.so
   637392  04-13-2022 15:57   ants/lib/fitBsplineDisplacementFieldToScatteredData.cpython-37m-x86_64-linux-gnu.so
  1398464  04-13-2022 15:57   ants/lib/antsImageMutualInformation.cpython-37m-x86_64-linux-gnu.so
  3524648  04-13-2022 15:57   ants/lib/KellyKapowski.cpython-37m-x86_64-linux-gnu.so
  6468352  04-13-2022 15:57   ants/lib/iMath.cpython-37m-x86_64-linux-gnu.so
 54190016  04-13-2022 15:57   ants/lib/antsRegistration.cpython-37m-x86_64-linux-gnu.so
   238200  04-13-2022 15:57   ants/lib/fsl2antstransform.cpython-37m-x86_64-linux-gnu.so
   440272  04-13-2022 15:57   ants/lib/labelOverlapMeasures.cpython-37m-x86_64-linux-gnu.so
  1490944  04-13-2022 15:57   ants/lib/fitBsplineObjectToScatteredData.cpython-37m-x86_64-linux-gnu.so
   203048  04-13-2022 15:57   ants/lib/reorientImage.cpython-37m-x86_64-linux-gnu.so
   914624  04-13-2022 15:57   ants/lib/hausdorffDistance.cpython-37m-x86_64-linux-gnu.so
   174840  04-13-2022 15:57   ants/lib/antsImageUtils.cpython-37m-x86_64-linux-gnu.so
   374832  04-13-2022 15:57   ants/lib/labelStats.cpython-37m-x86_64-linux-gnu.so
  4803664  04-13-2022 15:57   ants/lib/antsTransform.cpython-37m-x86_64-linux-gnu.so
   448536  04-13-2022 15:57   ants/lib/padImage.cpython-37m-x86_64-linux-gnu.so
   341216  04-13-2022 15:57   ants/lib/sliceImage.cpython-37m-x86_64-linux-gnu.so
   669448  04-13-2022 15:57   ants/lib/antiAlias.cpython-37m-x86_64-linux-gnu.so
   479920  04-13-2022 15:57   ants/lib/antsImageClone.cpython-37m-x86_64-linux-gnu.so
     2349  04-13-2022 15:57   ants/lib/__init__.py
   399432  04-13-2022 15:57   ants/lib/addNoiseToImage.cpython-37m-x86_64-linux-gnu.so
   586320  04-13-2022 15:57   ants/lib/integrateVelocityField.cpython-37m-x86_64-linux-gnu.so
   779512  04-13-2022 15:57   ants/lib/rgbToVector.cpython-37m-x86_64-linux-gnu.so
  1478880  04-13-2022 15:57   ants/lib/ThresholdImage.cpython-37m-x86_64-linux-gnu.so
  1235360  04-13-2022 15:57   ants/lib/sccaner.cpython-37m-x86_64-linux-gnu.so
   711328  04-13-2022 15:57   ants/lib/getNeighborhoodMatrix.cpython-37m-x86_64-linux-gnu.so
  2042360  04-13-2022 15:57   ants/lib/antsImageToImageMetric.cpython-37m-x86_64-linux-gnu.so
  1957296  04-13-2022 15:57   ants/lib/DenoiseImage.cpython-37m-x86_64-linux-gnu.so
  4876488  04-13-2022 15:57   ants/lib/Atropos.cpython-37m-x86_64-linux-gnu.so
   931024  04-13-2022 15:57   ants/lib/CreateJacobianDeterminantImage.cpython-37m-x86_64-linux-gnu.so
   825872  04-13-2022 15:57   ants/lib/TileImages.cpython-37m-x86_64-linux-gnu.so
   601504  04-13-2022 15:57   ants/lib/cropImage.cpython-37m-x86_64-linux-gnu.so
   447200  04-13-2022 15:57   ants/lib/mergeChannels.cpython-37m-x86_64-linux-gnu.so
  6307168  04-13-2022 15:57   ants/lib/ResampleImage.cpython-37m-x86_64-linux-gnu.so
   592424  04-13-2022 15:57   ants/lib/SmoothImage.cpython-37m-x86_64-linux-gnu.so
   523680  04-13-2022 15:57   ants/lib/weingartenImageCurvature.cpython-37m-x86_64-linux-gnu.so
 11610104  04-13-2022 15:57   ants/lib/antsApplyTransforms.cpython-37m-x86_64-linux-gnu.so
   641416  04-13-2022 15:57   ants/lib/fitBsplineDisplacementField.cpython-37m-x86_64-linux-gnu.so
  1490920  04-13-2022 15:57   ants/lib/LabelGeometryMeasures.cpython-37m-x86_64-linux-gnu.so
  2769392  04-13-2022 15:57   ants/lib/antsApplyTransformsToPoints.cpython-37m-x86_64-linux-gnu.so
  1793616  04-13-2022 15:57   ants/lib/readImage.cpython-37m-x86_64-linux-gnu.so
  2958296  04-13-2022 15:57   ants/lib/N3BiasFieldCorrection.cpython-37m-x86_64-linux-gnu.so
   662752  04-13-2022 15:57   ants/lib/readTransform.cpython-37m-x86_64-linux-gnu.so
   312560  04-13-2022 15:57   ants/lib/reorientImage2.cpython-37m-x86_64-linux-gnu.so
   465896  04-13-2022 15:57   ants/lib/histogramMatchImage.cpython-37m-x86_64-linux-gnu.so
  2183664  04-13-2022 15:57   ants/lib/N4BiasFieldCorrection.cpython-37m-x86_64-linux-gnu.so
  1209112  04-13-2022 15:57   ants/lib/LabelClustersUniquely.cpython-37m-x86_64-linux-gnu.so
  1250584  04-13-2022 15:57   ants/lib/CreateTiledMosaic.cpython-37m-x86_64-linux-gnu.so
   737952  04-13-2022 15:57   ants/lib/ConvertScalarImageToRGB.cpython-37m-x86_64-linux-gnu.so
        0  04-13-2022 15:57   ants/contrib/sampling/
        0  04-13-2022 15:57   ants/contrib/bids/
        0  04-13-2022 15:57   ants/contrib/sklearn_interface/
       59  04-13-2022 15:57   ants/contrib/__init__.py
    21671  04-13-2022 15:57   ants/contrib/sampling/affine2d.py
    24051  04-13-2022 15:57   ants/contrib/sampling/affine3d.py
    24297  04-13-2022 15:57   ants/contrib/sampling/transforms.py
       75  04-13-2022 15:57   ants/contrib/sampling/__init__.py
       22  04-13-2022 15:57   ants/contrib/bids/__init__.py
     3032  04-13-2022 15:57   ants/contrib/bids/cohort.py
       37  04-13-2022 15:57   ants/contrib/sklearn_interface/__init__.py
     5900  04-13-2022 15:57   ants/contrib/sklearn_interface/sklearn_registration.py
     2134  04-13-2022 15:57   ants/segmentation/prior_based_segmentation.py
      968  04-13-2022 15:57   ants/segmentation/otsu.py
     1955  04-13-2022 15:57   ants/segmentation/kelly_kapowski.py
     1421  04-13-2022 15:57   ants/segmentation/label_geometry_measures.py
      401  04-13-2022 15:57   ants/segmentation/__init__.py
     1101  04-13-2022 15:57   ants/segmentation/anti_alias.py
     6278  04-13-2022 15:57   ants/segmentation/functional_lung_segmentation.py
     1247  04-13-2022 15:57   ants/segmentation/kmeans.py
    18925  04-13-2022 15:57   ants/segmentation/joint_label_fusion.py
     5106  04-13-2022 15:57   ants/segmentation/fuzzy_spatial_cmeans_segmentation.py
     5204  04-13-2022 15:57   ants/segmentation/atropos.py
     4152  04-13-2022 15:57   ants/viz/create_tiled_mosaic.py
    26238  04-13-2022 15:57   ants/viz/volume.py
      139  04-13-2022 15:57   ants/viz/__init__.py
    31219  04-13-2022 15:57   ants/viz/surface.py
    87442  04-13-2022 15:57   ants/viz/plot.py
     5503  04-13-2022 15:57   ants/viz/render_surface_function.py
     3155  04-13-2022 15:57   ants/core/ants_metric_io.py
    33118  04-13-2022 15:57   ants/core/ants_image.py
    17883  04-13-2022 15:57   ants/core/ants_image_io.py
      177  04-13-2022 15:57   ants/core/__init__.py
    14318  04-13-2022 15:57   ants/core/ants_transform.py
     9158  04-13-2022 15:57   ants/core/ants_transform_io.py
     4438  04-13-2022 15:57   ants/core/ants_metric.py
     3143  04-13-2022 15:57   ants/registration/build_template.py
     1376  04-13-2022 15:57   ants/registration/symmetrize_image.py
      452  04-13-2022 15:57   ants/registration/__init__.py
     3991  04-13-2022 15:57   ants/registration/create_warped_grid.py
     5955  04-13-2022 15:57   ants/registration/resample_image.py
     1024  04-13-2022 15:57   ants/registration/metrics.py
     1533  04-13-2022 15:57   ants/registration/reflect_image.py
     3033  04-13-2022 15:57   ants/registration/reorient_image.py
    63183  04-13-2022 15:57   ants/registration/interface.py
     1750  04-13-2022 15:57   ants/registration/make_points_image.py
     1708  04-13-2022 15:57   ants/registration/create_jacobian_determinant_image.py
     1359  04-13-2022 15:57   ants/registration/fsl2antstransform.py
     2581  04-13-2022 15:57   ants/registration/landmark_transforms.py
    12151  04-13-2022 15:57   ants/registration/apply_transforms.py
     2116  04-13-2022 15:57   ants/registration/affine_initializer.py
---------                     -------
212831973                     270 files
```

#### Current version of `auditwheel`
```shell
[root@2b2bee6ed3f3 wheelhouse]# unzip -l wheelhouse-old/antspyx-0.3.2+hri.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
Archive:  wheelhouse-old/antspyx-0.3.2+hri.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  04-13-2022 15:59   antspyx.libs/
        0  04-13-2022 15:59   antspyx-0.3.2+hri.0.dist-info/
        0  04-13-2022 15:59   ants/
   534824  04-13-2022 15:59   antspyx.libs/libitktiff-5-676c3f9f.3.so.1
   404096  04-13-2022 15:59   antspyx.libs/libitkgdcmopenjp2-5-21100300.3.so.1
   101104  04-13-2022 15:59   antspyx.libs/libITKRegistrationMethodsv4-5-5768b011.3.so.1
   295912  04-13-2022 15:59   antspyx.libs/libITKIOTransformMatlab-5-2e6a88da.3.so.1
   248312  04-13-2022 15:59   antspyx.libs/libITKIOLSM-5-bd6bdcb3.3.so.1
   584016  04-13-2022 15:59   antspyx.libs/libitksys-5-9387fd6e.3.so.1
  1132200  04-13-2022 15:59   antspyx.libs/libITKOptimizers-5-825fe76b.3.so.1
    72976  04-13-2022 15:59   antspyx.libs/libITKPolynomials-5-7acf0399.3.so.1
   531888  04-13-2022 15:59   antspyx.libs/libitkminc2-5-b55b2e59.3.so.1
   276232  04-13-2022 15:59   antspyx.libs/libITKIOMeshBYU-5-af5ee9b7.3.so.1
  2846352  04-13-2022 15:59   antspyx.libs/libitkgdcmDICT-5-602b02a3.3.so.1
    67856  04-13-2022 15:59   antspyx.libs/libITKMesh-5-33e82eca.3.so.1
   140952  04-13-2022 15:59   antspyx.libs/libITKIOCSV-5-5d35fb7f.3.so.1
   221408  04-13-2022 15:59   antspyx.libs/libITKgiftiio-5-34e6384e.3.so.1
   812224  04-13-2022 15:59   antspyx.libs/libITKSpatialObjects-5-e8152a73.3.so.1
  1680448  04-13-2022 15:59   antspyx.libs/libitkvnl_algo-5-e6ce72e1.3.so.1
    17216  04-13-2022 15:59   antspyx.libs/libITKSmoothing-5-141064e8.3.so.1
    41456  04-13-2022 15:59   antspyx.libs/libitkNetlibSlatec-5-e614f7e3.3.so.1
   313424  04-13-2022 15:59   antspyx.libs/libitkjpeg-5-3bbeee3a.3.so.1
   759176  04-13-2022 15:59   antspyx.libs/libITKIOTransformBase-5-121f2389.3.so.1
    21512  04-13-2022 15:59   antspyx.libs/libITKDenoising-5-00f91b7d.3.so.1
  1208520  04-13-2022 15:59   antspyx.libs/libITKIOMeshVTK-5-09a0899c.3.so.1
  1322152  04-13-2022 15:59   antspyx.libs/libitkgdcmDSED-5-e6ec6a7b.3.so.1
  6527496  04-13-2022 15:59   antspyx.libs/libITKFFT-5-ea8e03b8.3.so.1
    70848  04-13-2022 15:59   antspyx.libs/libITKRegionGrowing-5-c45e7396.3.so.1
   169280  04-13-2022 15:59   antspyx.libs/libITKWatersheds-5-29b97520.3.so.1
   327920  04-13-2022 15:59   antspyx.libs/libITKIOXML-5-3a1e8b08.3.so.1
   234104  04-13-2022 15:59   antspyx.libs/libITKIOMeshBase-5-6fec2de6.3.so.1
   154920  04-13-2022 15:59   antspyx.libs/libITKKLMRegionGrowing-5-e9d012cc.3.so.1
   219712  04-13-2022 15:59   antspyx.libs/libITKIOGIPL-5-b7f79d5a.3.so.1
  5013840  04-13-2022 15:59   antspyx.libs/libitkhdf5-shared-5-cfd06ae4.3.so.1
    21656  04-13-2022 15:59   antspyx.libs/libitkvcl-5-bb700565.3.so.1
   340272  04-13-2022 15:59   antspyx.libs/libITKNrrdIO-5-ca003690.3.so.1
    83336  04-13-2022 15:59   antspyx.libs/libITKPDEDeformableRegistration-5-551d8f54.3.so.1
    70848  04-13-2022 15:59   antspyx.libs/libITKMathematicalMorphology-5-7a3f72c7.3.so.1
   469696  04-13-2022 15:59   antspyx.libs/libITKIOMeshGifti-5-69409b91.3.so.1
    62656  04-13-2022 15:59   antspyx.libs/libITKQuadEdgeMeshFiltering-5-67af6c32.3.so.1
    37408  04-13-2022 15:59   antspyx.libs/libITKVNLInstantiation-5-9c5f799d.3.so.1
   403272  04-13-2022 15:59   antspyx.libs/libITKIONIFTI-5-4f0ac868.3.so.1
   246520  04-13-2022 15:59   antspyx.libs/libitkgdcmjpeg8-5-c066f1af.3.so.1
   291936  04-13-2022 15:59   antspyx.libs/libITKIOIPL-5-b8ad9712.3.so.1
   211336  04-13-2022 15:59   antspyx.libs/libITKIOSiemens-5-228a2bc0.3.so.1
   382056  04-13-2022 15:59   antspyx.libs/libITKIOMeshFreeSurfer-5-4e372563.3.so.1
   109576  04-13-2022 15:59   antspyx.libs/libitkgdcmCommon-5-49c20d24.3.so.1
   238448  04-13-2022 15:59   antspyx.libs/libitkgdcmjpeg12-5-4d714595.3.so.1
   977144  04-13-2022 15:59   antspyx.libs/libITKMetaIO-5-8bf156dd.3.so.1
   237648  04-13-2022 15:59   antspyx.libs/libitkopenjpeg-5-1a34806f.3.so.1
   228368  04-13-2022 15:59   antspyx.libs/libITKIOJPEG-5-d06d0bfe.3.so.1
   282640  04-13-2022 15:59   antspyx.libs/libITKIOJPEG2000-5-42f282e4.3.so.1
    75000  04-13-2022 15:59   antspyx.libs/libITKConvolution-5-091f396c.3.so.1
   309880  04-13-2022 15:59   antspyx.libs/libITKIOGE-5-6163aea1.3.so.1
    68240  04-13-2022 15:59   antspyx.libs/libITKQuadEdgeMesh-5-2c5b682d.3.so.1
   215824  04-13-2022 15:59   antspyx.libs/libITKIOBMP-5-9aaf95d2.3.so.1
    29128  04-13-2022 15:59   antspyx.libs/libITKznz-5-488075b2.3.so.1
   691296  04-13-2022 15:59   antspyx.libs/libITKIOHDF5-5-daaa54a0.3.so.1
   404136  04-13-2022 15:59   antspyx.libs/libITKIOMeta-5-7d3e013b.3.so.1
   207944  04-13-2022 15:59   antspyx.libs/libITKIOBioRad-5-d193602d.3.so.1
   324472  04-13-2022 15:59   antspyx.libs/libITKIONRRD-5-a59385d5.3.so.1
   187360  04-13-2022 15:59   antspyx.libs/libpng15-ce838cd1.so.15.13.0
   220464  04-13-2022 15:59   antspyx.libs/libITKIOStimulate-5-78e40c98.3.so.1
   339512  04-13-2022 15:59   antspyx.libs/libITKIOBruker-5-f2fcb35b.3.so.1
   669152  04-13-2022 15:59   antspyx.libs/libITKIOGDCM-5-989e05ac.3.so.1
   375760  04-13-2022 15:59   antspyx.libs/libITKIOMINC-5-c6454c1a.3.so.1
    62552  04-13-2022 15:59   antspyx.libs/libITKImageFeature-5-7b832af5.3.so.1
  3514912  04-13-2022 15:59   antspyx.libs/libITKCommon-5-77580bde.3.so.1
   624232  04-13-2022 15:59   antspyx.libs/libitkgdcmcharls-5-473d5561.3.so.1
   154120  04-13-2022 15:59   antspyx.libs/libitkzlib-5-8d51c88c.3.so.1.2.11.zlib-ng
   132136  04-13-2022 15:59   antspyx.libs/libitkgdcmIOD-5-870e3d40.3.so.1
    80408  04-13-2022 15:59   antspyx.libs/libITKBiasCorrection-5-47fce04b.3.so.1
   422288  04-13-2022 15:59   antspyx.libs/libITKIOTransformHDF5-5-7be9b192.3.so.1
    85864  04-13-2022 15:59   antspyx.libs/libitkdouble-conversion-5-61107de3.3.so.1
 26420368  04-13-2022 15:59   antspyx.libs/libITKTestKernel-5-748bf3ac.3.so.1
   225248  04-13-2022 15:59   antspyx.libs/libITKEXPAT-5-1151843b.3.so.1
    59744  04-13-2022 15:59   antspyx.libs/libITKTransform-5-dd17e93c.3.so.1
 16244608  04-13-2022 15:59   antspyx.libs/libITKTransformFactory-5-4de6fc0d.3.so.1
   565344  04-13-2022 15:59   antspyx.libs/libITKOptimizersv4-5-db98c968.3.so.1
   245128  04-13-2022 15:59   antspyx.libs/libitkMGHIO-5-8f2e6e10.3.so.1
 17373256  04-13-2022 15:59   antspyx.libs/libitkvnl-5-e8086a45.3.so.1
   297400  04-13-2022 15:59   antspyx.libs/libITKIOMRC-5-06d7de70.3.so.1
    70864  04-13-2022 15:59   antspyx.libs/libitkAdaptiveDenoising-5-294cf63d.3.so.1
    83320  04-13-2022 15:59   antspyx.libs/libITKDeformableMesh-5-8ad25a88.3.so.1
    70856  04-13-2022 15:59   antspyx.libs/libITKMarkovRandomFieldsClassifiers-5-cc3df7c8.3.so.1
   184904  04-13-2022 15:59   antspyx.libs/libITKPath-5-5fccea1d.3.so.1
    21504  04-13-2022 15:59   antspyx.libs/libITKFastMarching-5-fd67f682.3.so.1
   174872  04-13-2022 15:59   antspyx.libs/libITKniftiio-5-a1167cd6.3.so.1
    21264  04-13-2022 15:59   antspyx.libs/libitkgdcmuuid-5-117fa7ed.3.so.1
   334072  04-13-2022 15:59   antspyx.libs/libITKIOTransformInsightLegacy-5-a76ca6b1.3.so.1
    33488  04-13-2022 15:59   antspyx.libs/libitklbfgs-5-3edcb43b.3.so.1
    17216  04-13-2022 15:59   antspyx.libs/libITKColormap-5-f97d9f44.3.so.1
   828128  04-13-2022 15:59   antspyx.libs/libITKIOSpatialObjects-5-4ceb105d.3.so.1
  1266800  04-13-2022 15:59   antspyx.libs/libITKReview-5-1d7e8309.3.so.1
  1161040  04-13-2022 15:59   antspyx.libs/libitkv3p_netlib-5-4b54c378.3.so.1
    17256  04-13-2022 15:59   antspyx.libs/libITKDiffusionTensorImage-5-a34c123e.3.so.1
   331440  04-13-2022 15:59   antspyx.libs/libITKStatistics-5-a16b04cd.3.so.1
   305776  04-13-2022 15:59   antspyx.libs/libITKIOMeshOBJ-5-55a0b54c.3.so.1
   238448  04-13-2022 15:59   antspyx.libs/libitkgdcmjpeg16-5-2b4df9be.3.so.1
   303640  04-13-2022 15:59   antspyx.libs/libITKIOVTK-5-c91247dc.3.so.1
   236584  04-13-2022 15:59   antspyx.libs/libITKIOPNG-5-c368b6c6.3.so.1
   856720  04-13-2022 15:59   antspyx.libs/libitkhdf5_cpp-shared-5-25b86089.3.so.1
    75208  04-13-2022 15:59   antspyx.libs/libITKLabelMap-5-8820f3fa.3.so.1
   322008  04-13-2022 15:59   antspyx.libs/libITKIOMeshOFF-5-3fb02870.3.so.1
   139208  04-13-2022 15:59   antspyx.libs/libITKVTK-5-8f97fa3a.3.so.1
   400680  04-13-2022 15:59   antspyx.libs/libITKIOTIFF-5-d178402b.3.so.1
  3897784  04-13-2022 15:59   antspyx.libs/libitkgdcmMSFF-5-f7a8c9e7.3.so.1
   454672  04-13-2022 15:59   antspyx.libs/libITKIOImageBase-5-105668d8.3.so.1
    11357  04-13-2022 15:59   antspyx-0.3.2+hri.0.dist-info/LICENSE
        5  04-13-2022 15:59   antspyx-0.3.2+hri.0.dist-info/top_level.txt
     5836  04-13-2022 15:59   antspyx-0.3.2+hri.0.dist-info/METADATA
    26180  04-13-2022 15:59   antspyx-0.3.2+hri.0.dist-info/RECORD
      150  04-13-2022 15:59   antspyx-0.3.2+hri.0.dist-info/WHEEL
        0  04-13-2022 15:59   ants/learn/
        0  04-13-2022 15:59   ants/utils/
        0  04-13-2022 15:59   ants/lib/
        0  04-13-2022 15:59   ants/contrib/
        0  04-13-2022 15:59   ants/segmentation/
        0  04-13-2022 15:59   ants/viz/
        0  04-13-2022 15:59   ants/core/
        0  04-13-2022 15:59   ants/registration/
       28  04-13-2022 15:59   ants/version.py
      221  04-13-2022 15:59   ants/__init__.py
       29  04-13-2022 15:59   ants/learn/__init__.py
    13566  04-13-2022 15:59   ants/learn/decomposition.py
     1007  04-13-2022 15:59   ants/utils/hausdorff_distance.py
     2490  04-13-2022 15:59   ants/utils/label_image_centroids.py
     3400  04-13-2022 15:59   ants/utils/ndimage_to_list.py
     2321  04-13-2022 15:59   ants/utils/denoise_image.py
     4863  04-13-2022 15:59   ants/utils/impute.py
     2480  04-13-2022 15:59   ants/utils/smooth_image.py
     4161  04-13-2022 15:59   ants/utils/morphology.py
     2435  04-13-2022 15:59   ants/utils/ants_integrate_velocity_field.py
     1624  04-13-2022 15:59   ants/utils/histogram_match_image.py
     6473  04-13-2022 15:59   ants/utils/get_neighborhood.py
     1397  04-13-2022 15:59   ants/utils/image_to_cluster_images.py
     1023  04-13-2022 15:59   ants/utils/label_stats.py
     8235  04-13-2022 15:59   ants/utils/fit_bspline_object_to_scattered_data.py
     1162  04-13-2022 15:59   ants/utils/label_overlap_measures.py
     7974  04-13-2022 15:59   ants/utils/invariant_image_similarity.py
     2517  04-13-2022 15:59   ants/utils/channels.py
     1500  04-13-2022 15:59   ants/utils/get_centroids.py
     1903  04-13-2022 15:59   ants/utils/labels_to_matrix.py
     1572  04-13-2022 15:59   ants/utils/convert_nibabel.py
     1248  04-13-2022 15:59   ants/utils/__init__.py
     5923  04-13-2022 15:59   ants/utils/iMath.py
     8429  04-13-2022 15:59   ants/utils/fit_bspline_displacement_field.py
     1436  04-13-2022 15:59   ants/utils/label_clusters.py
     3976  04-13-2022 15:59   ants/utils/multi_label_morphology.py
     1875  04-13-2022 15:59   ants/utils/weingarten_image_curvature.py
      819  04-13-2022 15:59   ants/utils/slice_image.py
     2609  04-13-2022 15:59   ants/utils/get_mask.py
     1536  04-13-2022 15:59   ants/utils/mask_image.py
    13623  04-13-2022 15:59   ants/utils/quantile.py
     4392  04-13-2022 15:59   ants/utils/crop_image.py
     9863  04-13-2022 15:59   ants/utils/bias_correction.py
     2969  04-13-2022 15:59   ants/utils/get_ants_data.py
     2364  04-13-2022 15:59   ants/utils/process_args.py
     4171  04-13-2022 15:59   ants/utils/scalar_rgb_vector.py
     2500  04-13-2022 15:59   ants/utils/pad_image.py
     1609  04-13-2022 15:59   ants/utils/threshold_image.py
     3368  04-13-2022 15:59   ants/utils/simulate_displacement_field.py
     1716  04-13-2022 15:59   ants/utils/image_similarity.py
     1377  04-13-2022 15:59   ants/utils/mni2tal.py
     3211  04-13-2022 15:59   ants/utils/add_noise_to_image.py
  4020280  04-13-2022 15:59   ants/lib/antsImageAugment.cpython-37m-x86_64-linux-gnu.so
  2131496  04-13-2022 15:59   ants/lib/reflectionMatrix.cpython-37m-x86_64-linux-gnu.so
  1353136  04-13-2022 15:59   ants/lib/antsImageHeaderInfo.cpython-37m-x86_64-linux-gnu.so
  4966256  04-13-2022 15:59   ants/lib/antsJointFusion.cpython-37m-x86_64-linux-gnu.so
  3228216  04-13-2022 15:59   ants/lib/antsImage.cpython-37m-x86_64-linux-gnu.so
  5588928  04-13-2022 15:59   ants/lib/antsAffineInitializer.cpython-37m-x86_64-linux-gnu.so
  3825976  04-13-2022 15:59   ants/lib/simulateDisplacementField.cpython-37m-x86_64-linux-gnu.so
  2685392  04-13-2022 15:59   ants/lib/fitBsplineDisplacementFieldToScatteredData.cpython-37m-x86_64-linux-gnu.so
  3811008  04-13-2022 15:59   ants/lib/antsImageMutualInformation.cpython-37m-x86_64-linux-gnu.so
  7149608  04-13-2022 15:59   ants/lib/KellyKapowski.cpython-37m-x86_64-linux-gnu.so
  9605888  04-13-2022 15:59   ants/lib/iMath.cpython-37m-x86_64-linux-gnu.so
740409280  04-13-2022 15:59   ants/lib/antsRegistration.cpython-37m-x86_64-linux-gnu.so
  1745528  04-13-2022 15:59   ants/lib/fsl2antstransform.cpython-37m-x86_64-linux-gnu.so
  2451408  04-13-2022 15:59   ants/lib/labelOverlapMeasures.cpython-37m-x86_64-linux-gnu.so
  3731456  04-13-2022 15:59   ants/lib/fitBsplineObjectToScatteredData.cpython-37m-x86_64-linux-gnu.so
  1576536  04-13-2022 15:59   ants/lib/reorientImage.cpython-37m-x86_64-linux-gnu.so
  3302592  04-13-2022 15:59   ants/lib/hausdorffDistance.cpython-37m-x86_64-linux-gnu.so
  1369472  04-13-2022 15:59   ants/lib/antsImageUtils.cpython-37m-x86_64-linux-gnu.so
  2385968  04-13-2022 15:59   ants/lib/labelStats.cpython-37m-x86_64-linux-gnu.so
  7330896  04-13-2022 15:59   ants/lib/antsTransform.cpython-37m-x86_64-linux-gnu.so
  2459672  04-13-2022 15:59   ants/lib/padImage.cpython-37m-x86_64-linux-gnu.so
  2331872  04-13-2022 15:59   ants/lib/sliceImage.cpython-37m-x86_64-linux-gnu.so
  2684680  04-13-2022 15:59   ants/lib/antiAlias.cpython-37m-x86_64-linux-gnu.so
  1995440  04-13-2022 15:59   ants/lib/antsImageClone.cpython-37m-x86_64-linux-gnu.so
     2349  04-13-2022 15:59   ants/lib/__init__.py
  2410568  04-13-2022 15:59   ants/lib/addNoiseToImage.cpython-37m-x86_64-linux-gnu.so
  2896464  04-13-2022 15:59   ants/lib/integrateVelocityField.cpython-37m-x86_64-linux-gnu.so
  2770168  04-13-2022 15:59   ants/lib/rgbToVector.cpython-37m-x86_64-linux-gnu.so
  4149472  04-13-2022 15:59   ants/lib/ThresholdImage.cpython-37m-x86_64-linux-gnu.so
  3684768  04-13-2022 15:59   ants/lib/sccaner.cpython-37m-x86_64-linux-gnu.so
  2096816  04-13-2022 15:59   ants/lib/getNeighborhoodMatrix.cpython-37m-x86_64-linux-gnu.so
  4499960  04-13-2022 15:59   ants/lib/antsImageToImageMetric.cpython-37m-x86_64-linux-gnu.so
  5336496  04-13-2022 15:59   ants/lib/DenoiseImage.cpython-37m-x86_64-linux-gnu.so
  8911048  04-13-2022 15:59   ants/lib/Atropos.cpython-37m-x86_64-linux-gnu.so
  3318992  04-13-2022 15:59   ants/lib/CreateJacobianDeterminantImage.cpython-37m-x86_64-linux-gnu.so
  3287568  04-13-2022 15:59   ants/lib/TileImages.cpython-37m-x86_64-linux-gnu.so
  2768288  04-13-2022 15:59   ants/lib/cropImage.cpython-37m-x86_64-linux-gnu.so
  1966816  04-13-2022 15:59   ants/lib/mergeChannels.cpython-37m-x86_64-linux-gnu.so
  8867168  04-13-2022 15:59   ants/lib/ResampleImage.cpython-37m-x86_64-linux-gnu.so
  2648616  04-13-2022 15:59   ants/lib/SmoothImage.cpython-37m-x86_64-linux-gnu.so
  2690464  04-13-2022 15:59   ants/lib/weingartenImageCurvature.cpython-37m-x86_64-linux-gnu.so
 15239160  04-13-2022 15:59   ants/lib/antsApplyTransforms.cpython-37m-x86_64-linux-gnu.so
  2681224  04-13-2022 15:59   ants/lib/fitBsplineDisplacementField.cpython-37m-x86_64-linux-gnu.so
  4136936  04-13-2022 15:59   ants/lib/LabelGeometryMeasures.cpython-37m-x86_64-linux-gnu.so
  6283760  04-13-2022 15:59   ants/lib/antsApplyTransformsToPoints.cpython-37m-x86_64-linux-gnu.so
  3980880  04-13-2022 15:59   ants/lib/readImage.cpython-37m-x86_64-linux-gnu.so
  6521816  04-13-2022 15:59   ants/lib/N3BiasFieldCorrection.cpython-37m-x86_64-linux-gnu.so
  2399456  04-13-2022 15:59   ants/lib/readTransform.cpython-37m-x86_64-linux-gnu.so
  2303216  04-13-2022 15:59   ants/lib/reorientImage2.cpython-37m-x86_64-linux-gnu.so
  2579432  04-13-2022 15:59   ants/lib/histogramMatchImage.cpython-37m-x86_64-linux-gnu.so
  5698032  04-13-2022 15:59   ants/lib/N4BiasFieldCorrection.cpython-37m-x86_64-linux-gnu.so
  3949336  04-13-2022 15:59   ants/lib/LabelClustersUniquely.cpython-37m-x86_64-linux-gnu.so
  4453656  04-13-2022 15:59   ants/lib/CreateTiledMosaic.cpython-37m-x86_64-linux-gnu.so
  3056288  04-13-2022 15:59   ants/lib/ConvertScalarImageToRGB.cpython-37m-x86_64-linux-gnu.so
        0  04-13-2022 15:59   ants/contrib/sampling/
        0  04-13-2022 15:59   ants/contrib/bids/
        0  04-13-2022 15:59   ants/contrib/sklearn_interface/
       59  04-13-2022 15:59   ants/contrib/__init__.py
    21671  04-13-2022 15:59   ants/contrib/sampling/affine2d.py
    24051  04-13-2022 15:59   ants/contrib/sampling/affine3d.py
    24297  04-13-2022 15:59   ants/contrib/sampling/transforms.py
       75  04-13-2022 15:59   ants/contrib/sampling/__init__.py
       22  04-13-2022 15:59   ants/contrib/bids/__init__.py
     3032  04-13-2022 15:59   ants/contrib/bids/cohort.py
       37  04-13-2022 15:59   ants/contrib/sklearn_interface/__init__.py
     5900  04-13-2022 15:59   ants/contrib/sklearn_interface/sklearn_registration.py
     2134  04-13-2022 15:59   ants/segmentation/prior_based_segmentation.py
      968  04-13-2022 15:59   ants/segmentation/otsu.py
     1955  04-13-2022 15:59   ants/segmentation/kelly_kapowski.py
     1421  04-13-2022 15:59   ants/segmentation/label_geometry_measures.py
      401  04-13-2022 15:59   ants/segmentation/__init__.py
     1101  04-13-2022 15:59   ants/segmentation/anti_alias.py
     6278  04-13-2022 15:59   ants/segmentation/functional_lung_segmentation.py
     1247  04-13-2022 15:59   ants/segmentation/kmeans.py
    18925  04-13-2022 15:59   ants/segmentation/joint_label_fusion.py
     5106  04-13-2022 15:59   ants/segmentation/fuzzy_spatial_cmeans_segmentation.py
     5204  04-13-2022 15:59   ants/segmentation/atropos.py
     4152  04-13-2022 15:59   ants/viz/create_tiled_mosaic.py
    26238  04-13-2022 15:59   ants/viz/volume.py
      139  04-13-2022 15:59   ants/viz/__init__.py
    31219  04-13-2022 15:59   ants/viz/surface.py
    87442  04-13-2022 15:59   ants/viz/plot.py
     5503  04-13-2022 15:59   ants/viz/render_surface_function.py
     3155  04-13-2022 15:59   ants/core/ants_metric_io.py
    33118  04-13-2022 15:59   ants/core/ants_image.py
    17883  04-13-2022 15:59   ants/core/ants_image_io.py
      177  04-13-2022 15:59   ants/core/__init__.py
    14318  04-13-2022 15:59   ants/core/ants_transform.py
     9158  04-13-2022 15:59   ants/core/ants_transform_io.py
     4438  04-13-2022 15:59   ants/core/ants_metric.py
     3143  04-13-2022 15:59   ants/registration/build_template.py
     1376  04-13-2022 15:59   ants/registration/symmetrize_image.py
      452  04-13-2022 15:59   ants/registration/__init__.py
     3991  04-13-2022 15:59   ants/registration/create_warped_grid.py
     5955  04-13-2022 15:59   ants/registration/resample_image.py
     1024  04-13-2022 15:59   ants/registration/metrics.py
     1533  04-13-2022 15:59   ants/registration/reflect_image.py
     3033  04-13-2022 15:59   ants/registration/reorient_image.py
    63183  04-13-2022 15:59   ants/registration/interface.py
     1750  04-13-2022 15:59   ants/registration/make_points_image.py
     1708  04-13-2022 15:59   ants/registration/create_jacobian_determinant_image.py
     1359  04-13-2022 15:59   ants/registration/fsl2antstransform.py
     2581  04-13-2022 15:59   ants/registration/landmark_transforms.py
    12151  04-13-2022 15:59   ants/registration/apply_transforms.py
     2116  04-13-2022 15:59   ants/registration/affine_initializer.py
---------                     -------
1061912019                     270 files
```

### Sample benchmark of `auditwheel repair` time
#### Proposed change
Note the speedup of ~3.6x in `real` time for this example. `user` time is not much changed so this is probably mostly I/O savings.
```shell
[root@2b2bee6ed3f3 wheelhouse]# time python3.7 -m auditwheel repair antspyx-0.3.2+hri.0-cp37-cp37m-linux_x86_64.whl -w wheelhouse-new
INFO:auditwheel.main_repair:Repairing antspyx-0.3.2+hri.0-cp37-cp37m-linux_x86_64.whl
INFO:auditwheel.wheeltools:Previous filename tags: linux_x86_64
INFO:auditwheel.wheeltools:New filename tags: manylinux_2_17_x86_64, manylinux2014_x86_64
INFO:auditwheel.wheeltools:Previous WHEEL info tags: cp37-cp37m-linux_x86_64
INFO:auditwheel.wheeltools:New WHEEL info tags: cp37-cp37m-manylinux_2_17_x86_64, cp37-cp37m-manylinux2014_x86_64
INFO:auditwheel.main_repair:
Fixed-up wheel written to /project/wheelhouse/wheelhouse-new/antspyx-0.3.2+hri.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl

real	1m31.075s
user	1m6.525s
sys	0m9.853s
```

#### Current version of `auditwheel`
```shell
[root@2b2bee6ed3f3 wheelhouse]# time python3.7 -m auditwheel repair antspyx-0.3.2+hri.0-cp37-cp37m-linux_x86_64.whl -w wheelhouse-old
INFO:auditwheel.main_repair:Repairing antspyx-0.3.2+hri.0-cp37-cp37m-linux_x86_64.whl
INFO:auditwheel.wheeltools:Previous filename tags: linux_x86_64
INFO:auditwheel.wheeltools:New filename tags: manylinux_2_17_x86_64, manylinux2014_x86_64
INFO:auditwheel.wheeltools:Previous WHEEL info tags: cp37-cp37m-linux_x86_64
INFO:auditwheel.wheeltools:New WHEEL info tags: cp37-cp37m-manylinux_2_17_x86_64, cp37-cp37m-manylinux2014_x86_64
INFO:auditwheel.main_repair:
Fixed-up wheel written to /project/wheelhouse/wheelhouse-old/antspyx-0.3.2+hri.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl

real	5m28.189s
user	1m37.816s
sys	2m53.355s
```