### PR TITLE
fix: add `/auditwheel_src` to git safe directories

### DIFF
--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -712,6 +712,7 @@ class TestManylinux(Anylinux):
         with tmp_docker_image(
             base,
             [
+                'git config --global --add safe.directory "/auditwheel_src"',
                 "pip install -U pip setuptools pytest-cov",
                 "pip install -U -e /auditwheel_src",
             ],
@@ -935,6 +936,7 @@ class TestMusllinux(Anylinux):
         with tmp_docker_image(
             base,
             [
+                'git config --global --add safe.directory "/auditwheel_src"',
                 "pip install -U pip setuptools pytest-cov",
                 "pip install -U -e /auditwheel_src",
             ],


### PR DESCRIPTION
The volume bound to the manylinux/musllinux for `/auditwheel_src` uses the host uid for file ownership which is different from the uid used inside the containers.

git now checks uid to allow/deny actions.

This adds `/auditwheel_src` to git safe directories to allow setuptools_scm to infer auditwheel version inside the containers.