### PR TITLE
Add runtime dependency on patchelf

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,6 @@ Requirements
 ------------
 - OS: Linux
 - Python: 3.6+
-- `patchelf <https://github.com/NixOS/patchelf>`_
 
 Only systems that use `ELF
 <https://en.wikipedia.org/wiki/Executable_and_Linkable_Format>`_-based linkage

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ include_package_data = True
 install_requires =
     pyelftools>=0.24
     importlib_metadata; python_version < "3.8"
+    patchelf
 packages = find:
 package_dir =
     =src

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 extras = {
-    "test": ["pytest>=3.4", "jsonschema", "pypatchelf", "pretend", "docker"],
+    "test": ["pytest>=3.4", "jsonschema", "pretend", "docker"],
     "coverage": ["pytest-cov"],
 }
 extras["develop"] = sum(extras.values(), [])


### PR DESCRIPTION
Use the PyPI version so users don't have to install this with the system
package manager.

Closes: #386 