### PR TITLE
feat: do not copy libraries in site-packages

### DIFF
--- a/src/auditwheel/main_addtag.py
+++ b/src/auditwheel/main_addtag.py
@@ -13,7 +13,7 @@ def configure_parser(sub_parsers):
         "-w",
         "--wheel-dir",
         dest="WHEEL_DIR",
-        help=("Directory to store new wheel file (default:" ' "wheelhouse/")'),
+        help="Directory to store new wheel file (default: %(default)r)",
         type=abspath,
         default="wheelhouse/",
     )

--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -105,8 +105,8 @@ wheel will abort processing of subsequent wheels.
         help=(
             "Do not copy libraries located in the site-packages directory from "
             "other packages. Just update the `rpath` only. The developer will "
-            "need to ensure that the skipped libraries are listed the package "
-            "install dependencies."
+            "need to ensure that the skipped libraries are listed in the "
+            "package install dependencies."
         ),
         default=True,  # default: COPY_SITE_LIBS=True
     )

--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -49,8 +49,10 @@ wheel will abort processing of subsequent wheels.
         metavar="PLATFORM",
         env="AUDITWHEEL_PLAT",
         dest="PLAT",
-        help="Desired target platform. See the available platforms under the "
-        f'PLATFORMS section below. (default: "{highest_policy}")',
+        help=(
+            "Desired target platform. See the available platforms under the "
+            "PLATFORMS section below. (default: %(default)r)"
+        ),
         choices=policy_names,
         default=highest_policy,
     )
@@ -59,7 +61,8 @@ wheel will abort processing of subsequent wheels.
         "--lib-sdir",
         dest="LIB_SDIR",
         help=(
-            "Subdirectory in packages to store copied libraries." ' (default: ".libs")'
+            "Subdirectory in packages to store copied libraries. "
+            "(default: %(default)r)"
         ),
         default=".libs",
     )
@@ -68,7 +71,7 @@ wheel will abort processing of subsequent wheels.
         "--wheel-dir",
         dest="WHEEL_DIR",
         type=abspath,
-        help=("Directory to store delocated wheels (default:" ' "wheelhouse/")'),
+        help="Directory to store delocated wheels (default: %(default)r)",
         default="wheelhouse/",
     )
     p.add_argument(
@@ -79,7 +82,7 @@ wheel will abort processing of subsequent wheels.
             "Do not update the wheel filename tags and WHEEL info"
             " to match the repaired platform tag."
         ),
-        default=True,
+        default=True,  # default: UPDATE_TAGS=True
     )
     p.add_argument(
         "--strip",
@@ -101,10 +104,11 @@ wheel will abort processing of subsequent wheels.
         action="store_false",
         help=(
             "Do not copy libraries located in the site-packages directory from "
-            "other packages (update rpath only). The developer will need to ensure "
-            "that the skipped libraries are listed the package install dependencies."
+            "other packages. Just update the `rpath` only. The developer will "
+            "need to ensure that the skipped libraries are listed the package "
+            "install dependencies."
         ),
-        default=True,
+        default=True,  # default: COPY_SITE_LIBS=True
     )
     p.set_defaults(func=execute)
 

--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -95,6 +95,17 @@ wheel will abort processing of subsequent wheels.
         help="Do not check for higher policy compatibility",
         default=False,
     )
+    p.add_argument(
+        "--no-copy-site-libs",
+        dest="COPY_SITE_LIBS",
+        action="store_false",
+        help=(
+            "Do not copy libraries located in the site-packages directory from "
+            "other packages (update rpath only). The developer will need to ensure "
+            "that the skipped libraries are listed the package install dependencies."
+        ),
+        default=True,
+    )
     p.set_defaults(func=execute)
 
 
@@ -170,6 +181,7 @@ def execute(args, p):
             update_tags=args.UPDATE_TAGS,
             patcher=patcher,
             strip=args.STRIP,
+            copy_site_libs=args.COPY_SITE_LIBS,
         )
 
         if out_wheel is not None:

--- a/src/auditwheel/patcher.py
+++ b/src/auditwheel/patcher.py
@@ -9,6 +9,9 @@ class ElfPatcher:
     def replace_needed(self, file_name: str, *old_new_pairs: Tuple[str, str]) -> None:
         raise NotImplementedError
 
+    def get_soname(self, file_name: str) -> str:
+        raise NotImplementedError
+
     def set_soname(self, file_name: str, new_so_name: str) -> None:
         raise NotImplementedError
 
@@ -52,6 +55,13 @@ class Patchelf(ElfPatcher):
                 ),
                 file_name,
             ]
+        )
+
+    def get_soname(self, file_name: str) -> str:
+        return (
+            check_output(["patchelf", "--print-soname", file_name])
+            .decode("utf-8")
+            .strip()
         )
 
     def set_soname(self, file_name: str, new_so_name: str) -> None:

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -111,7 +111,8 @@ def repair_wheel(
                     new_rpath = os.path.relpath(dest_dir, os.path.dirname(fn))
                     new_rpath = os.path.join("$ORIGIN", new_rpath)
                 else:
-                    new_rpath = None  # no new .so files are copied
+                    # no new .so files are copied
+                    new_rpath = None  # type: ignore
                 append_rpath_within_wheel(
                     fn,
                     new_rpath,

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -73,7 +73,7 @@ def repair_wheel(
         for fn, v in external_refs_by_fn.items():
             ext_libs = v[abis[0]]["libs"]  # type: Dict[str, str]
             replacements = []  # type: List[Tuple[str, str]]
-            src_path_to_real_sonames = {}  # type: Dict[str, str]
+            src_path_real_soname_map = {}  # type: Dict[str, str]
             same_soname_libs = defaultdict(set)  # type: Dict[str, Set[str]]
             for soname, src_path in ext_libs.items():
                 if src_path is None:
@@ -86,16 +86,13 @@ def repair_wheel(
                     )
 
                 real_soname = patcher.get_soname(src_path)
-                src_path_to_real_sonames[soname] = real_soname
+                src_path_real_soname_map[real_soname] = src_path
                 same_soname_libs[real_soname].add(soname)
 
             if not copy_site_libs:
                 for soname, src_path in ext_libs.items():
                     if "site-packages" in str(src_path).split(os.path.sep):
-                        try:
-                            del same_soname_libs[src_path_to_real_sonames[soname]]
-                        except KeyError:
-                            pass
+                        same_soname_libs.pop(src_path_real_soname_map[src_path], None)
 
             for real_soname, sonames in same_soname_libs.items():
                 if len(sonames) == 0:

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -187,7 +187,7 @@ def copylib(src_path: str, dest_dir: str, patcher: ElfPatcher) -> Tuple[str, str
 
 def append_rpath_within_wheel(
     lib_name: str,
-    rpath: Optional[str],
+    new_rpath: Optional[str],
     wheel_base_dir: str,
     patcher: ElfPatcher,
     *,
@@ -225,13 +225,13 @@ def append_rpath_within_wheel(
         )
         for rp in rpaths
     ]
+    if new_rpath is not None:
+        rpaths.append(new_rpath)
     # Remove duplicates while preserving ordering
     # Fake an OrderedSet using OrderedDict
-    rpath_set = OrderedDict([(old_rpath, "") for old_rpath in rpaths])
-    if rpath is not None:
-        rpath_set[rpath] = ""
+    rpaths = list(OrderedDict.fromkeys(rpaths))
 
-    patcher.set_rpath(lib_name, ":".join(rpath_set))
+    patcher.set_rpath(lib_name, ":".join(rpaths))
 
 
 def _is_valid_rpath(

--- a/tests/integration/test_bundled_wheels.py
+++ b/tests/integration/test_bundled_wheels.py
@@ -65,6 +65,7 @@ def test_wheel_source_date_epoch(tmp_path, monkeypatch):
         PLAT="manylinux_2_5_x86_64",
         STRIP=False,
         UPDATE_TAGS=True,
+        COPY_SITE_LIBS=True,
         WHEEL_DIR=str(wheel_output_path),
         WHEEL_FILE=[str(wheel_path)],
         cmd="repair",


### PR DESCRIPTION
Add a new option `--no-copy-site-libs` to skip libraries in site-packages for `auditwheel repair`.

This feature will significantly reduce the wheel file size if the referenced libraries are shipped with other PyPI packages.

**NOTE:** The developers may have their own risks in using this feature (e.g. they need to add the skipped library as an install dependency in `setup.py`).

Resolves #391
