### PR TITLE
Improve log message in case of NonPlatformWheel error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,11 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 target-version = ["py36", "py37", "py38", "py39"]
+extend-exclude = "src/auditwheel/_vendor"
 
 [tool.isort]
 profile = "black"
+extend_skip_glob = "src/auditwheel/_vendor/**/*.py"
 
 [tool.mypy]
 follow_imports = "silent"

--- a/src/auditwheel/main_addtag.py
+++ b/src/auditwheel/main_addtag.py
@@ -24,16 +24,17 @@ def execute(args, p):
     import os
 
     from ._vendor.wheel.wheelfile import WHEEL_INFO_RE
-    from .wheel_abi import NonPlatformWheel, analyze_wheel_abi
+    from .wheel_abi import (
+        NOT_PLATFORM_WHEEL_MESSAGE,
+        NonPlatformWheel,
+        analyze_wheel_abi,
+    )
     from .wheeltools import InWheelCtx, WheelToolsError, add_platforms
 
     try:
         wheel_abi = analyze_wheel_abi(args.WHEEL_FILE)
     except NonPlatformWheel:
-        logger.info(
-            "This does not look like a platform wheel"
-            ", no compiled extension file found in the wheel archive"
-        )
+        logger.info(NOT_PLATFORM_WHEEL_MESSAGE)
         return 1
 
     parsed_fname = WHEEL_INFO_RE.search(basename(args.WHEEL_FILE))

--- a/src/auditwheel/main_addtag.py
+++ b/src/auditwheel/main_addtag.py
@@ -30,7 +30,7 @@ def execute(args, p):
     try:
         wheel_abi = analyze_wheel_abi(args.WHEEL_FILE)
     except NonPlatformWheel:
-        logger.info(NonPlatformWheel.LogMessage)
+        logger.info(NonPlatformWheel.LOG_MESSAGE)
         return 1
 
     parsed_fname = WHEEL_INFO_RE.search(basename(args.WHEEL_FILE))

--- a/src/auditwheel/main_addtag.py
+++ b/src/auditwheel/main_addtag.py
@@ -24,17 +24,13 @@ def execute(args, p):
     import os
 
     from ._vendor.wheel.wheelfile import WHEEL_INFO_RE
-    from .wheel_abi import (
-        NOT_PLATFORM_WHEEL_MESSAGE,
-        NonPlatformWheel,
-        analyze_wheel_abi,
-    )
+    from .wheel_abi import NonPlatformWheel, analyze_wheel_abi
     from .wheeltools import InWheelCtx, WheelToolsError, add_platforms
 
     try:
         wheel_abi = analyze_wheel_abi(args.WHEEL_FILE)
     except NonPlatformWheel:
-        logger.info(NOT_PLATFORM_WHEEL_MESSAGE)
+        logger.info(NonPlatformWheel.LogMessage)
         return 1
 
     parsed_fname = WHEEL_INFO_RE.search(basename(args.WHEEL_FILE))

--- a/src/auditwheel/main_addtag.py
+++ b/src/auditwheel/main_addtag.py
@@ -30,7 +30,10 @@ def execute(args, p):
     try:
         wheel_abi = analyze_wheel_abi(args.WHEEL_FILE)
     except NonPlatformWheel:
-        logger.info("This does not look like a platform wheel")
+        logger.info(
+            "This does not look like a platform wheel"
+            ", no compiled extension file found in the wheel archive"
+        )
         return 1
 
     parsed_fname = WHEEL_INFO_RE.search(basename(args.WHEEL_FILE))

--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -116,7 +116,7 @@ def execute(args, p):
         try:
             wheel_abi = analyze_wheel_abi(wheel_file)
         except NonPlatformWheel:
-            logger.info(NonPlatformWheel.LogMessage)
+            logger.info(NonPlatformWheel.LOG_MESSAGE)
             return 1
 
         policy = get_policy_by_name(args.PLAT)

--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -102,11 +102,7 @@ def execute(args, p):
     import os
 
     from .repair import repair_wheel
-    from .wheel_abi import (
-        NOT_PLATFORM_WHEEL_MESSAGE,
-        NonPlatformWheel,
-        analyze_wheel_abi,
-    )
+    from .wheel_abi import NonPlatformWheel, analyze_wheel_abi
 
     for wheel_file in args.WHEEL_FILE:
         if not isfile(wheel_file):
@@ -120,7 +116,7 @@ def execute(args, p):
         try:
             wheel_abi = analyze_wheel_abi(wheel_file)
         except NonPlatformWheel:
-            logger.info(NOT_PLATFORM_WHEEL_MESSAGE)
+            logger.info(NonPlatformWheel.LogMessage)
             return 1
 
         policy = get_policy_by_name(args.PLAT)

--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -102,7 +102,11 @@ def execute(args, p):
     import os
 
     from .repair import repair_wheel
-    from .wheel_abi import NonPlatformWheel, analyze_wheel_abi
+    from .wheel_abi import (
+        NOT_PLATFORM_WHEEL_MESSAGE,
+        NonPlatformWheel,
+        analyze_wheel_abi,
+    )
 
     for wheel_file in args.WHEEL_FILE:
         if not isfile(wheel_file):
@@ -116,10 +120,7 @@ def execute(args, p):
         try:
             wheel_abi = analyze_wheel_abi(wheel_file)
         except NonPlatformWheel:
-            logger.info(
-                "This does not look like a platform wheel"
-                ", no compiled extension file found in the wheel archive"
-            )
+            logger.info(NOT_PLATFORM_WHEEL_MESSAGE)
             return 1
 
         policy = get_policy_by_name(args.PLAT)

--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -116,7 +116,10 @@ def execute(args, p):
         try:
             wheel_abi = analyze_wheel_abi(wheel_file)
         except NonPlatformWheel:
-            logger.info("This does not look like a platform wheel")
+            logger.info(
+                "This does not look like a platform wheel"
+                ", no compiled extension file found in the wheel archive"
+            )
             return 1
 
         policy = get_policy_by_name(args.PLAT)

--- a/src/auditwheel/main_show.py
+++ b/src/auditwheel/main_show.py
@@ -39,7 +39,10 @@ def execute(args, p):
     try:
         winfo = analyze_wheel_abi(args.WHEEL_FILE)
     except NonPlatformWheel:
-        logger.info("This does not look like a platform wheel")
+        logger.info(
+            "This does not look like a platform wheel"
+            ", no compiled extension file found in the wheel archive"
+        )
         return 1
 
     libs_with_versions = [

--- a/src/auditwheel/main_show.py
+++ b/src/auditwheel/main_show.py
@@ -39,7 +39,7 @@ def execute(args, p):
     try:
         winfo = analyze_wheel_abi(args.WHEEL_FILE)
     except NonPlatformWheel:
-        logger.info(NonPlatformWheel.LogMessage)
+        logger.info(NonPlatformWheel.LOG_MESSAGE)
         return 1
 
     libs_with_versions = [

--- a/src/auditwheel/main_show.py
+++ b/src/auditwheel/main_show.py
@@ -29,11 +29,7 @@ def execute(args, p):
         get_priority_by_name,
         load_policies,
     )
-    from .wheel_abi import (
-        NOT_PLATFORM_WHEEL_MESSAGE,
-        NonPlatformWheel,
-        analyze_wheel_abi,
-    )
+    from .wheel_abi import NonPlatformWheel, analyze_wheel_abi
 
     fn = basename(args.WHEEL_FILE)
 
@@ -43,7 +39,7 @@ def execute(args, p):
     try:
         winfo = analyze_wheel_abi(args.WHEEL_FILE)
     except NonPlatformWheel:
-        logger.info(NOT_PLATFORM_WHEEL_MESSAGE)
+        logger.info(NonPlatformWheel.LogMessage)
         return 1
 
     libs_with_versions = [

--- a/src/auditwheel/main_show.py
+++ b/src/auditwheel/main_show.py
@@ -29,7 +29,11 @@ def execute(args, p):
         get_priority_by_name,
         load_policies,
     )
-    from .wheel_abi import NonPlatformWheel, analyze_wheel_abi
+    from .wheel_abi import (
+        NOT_PLATFORM_WHEEL_MESSAGE,
+        NonPlatformWheel,
+        analyze_wheel_abi,
+    )
 
     fn = basename(args.WHEEL_FILE)
 
@@ -39,10 +43,7 @@ def execute(args, p):
     try:
         winfo = analyze_wheel_abi(args.WHEEL_FILE)
     except NonPlatformWheel:
-        logger.info(
-            "This does not look like a platform wheel"
-            ", no compiled extension file found in the wheel archive"
-        )
+        logger.info(NOT_PLATFORM_WHEEL_MESSAGE)
         return 1
 
     libs_with_versions = [

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -50,12 +50,11 @@ class WheelAbiError(Exception):
 class NonPlatformWheel(WheelAbiError):
     """No ELF binaries in the wheel"""
 
-
-NOT_PLATFORM_WHEEL_MESSAGE = (
-    "This does not look like a platform wheel, no ELF executable "
-    "or shared library file (including compiled Python C extension) "
-    "found in the wheel archive"
-)
+    LogMessage = (
+        "This does not look like a platform wheel, no ELF executable "
+        "or shared library file (including compiled Python C extension) "
+        "found in the wheel archive"
+    )
 
 
 @functools.lru_cache()

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -50,7 +50,7 @@ class WheelAbiError(Exception):
 class NonPlatformWheel(WheelAbiError):
     """No ELF binaries in the wheel"""
 
-    LogMessage = (
+    LOG_MESSAGE = (
         "This does not look like a platform wheel, no ELF executable "
         "or shared library file (including compiled Python C extension) "
         "found in the wheel archive"

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -51,6 +51,13 @@ class NonPlatformWheel(WheelAbiError):
     """No ELF binaries in the wheel"""
 
 
+NOT_PLATFORM_WHEEL_MESSAGE = (
+    "This does not look like a platform wheel, no ELF executable "
+    "or shared library file (including compiled Python C extension) "
+    "found in the wheel archive"
+)
+
+
 @functools.lru_cache()
 def get_wheel_elfdata(wheel_fn: str):
     full_elftree = {}


### PR DESCRIPTION
The current log message in case a wheel file contains no compiled extension is not very clear regarding that's the issue is.
I've tried to add a clarification that I how will make it clearer for uses to understand what when wrong

(I opened https://github.com/pypa/cibuildwheel/issues/1247 since it was not clear to me that the error meant, I though it was complaining about the file name abi identifier or something similar)