### PR TITLE
chore(deps): update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ exclude: ^src/auditwheel/_vendor/
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.1.0
   hooks:
   - id: check-builtin-literals
   - id: check-added-large-files
@@ -23,28 +23,28 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.24.0
+  rev: v2.30.1
   hooks:
   - id: pyupgrade
     args: ["--py36-plus"]
 
 - repo: https://github.com/psf/black
-  rev: 22.6.0
+  rev: 22.8.0
   hooks:
   - id: black
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.9.3
+  rev: 5.10.1
   hooks:
   - id: isort
 
 - repo: https://github.com/PyCQA/flake8
-  rev: 3.9.2
+  rev: 5.0.4
   hooks:
   - id: flake8
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910
+  rev: v0.931
   hooks:
   - id: mypy
     exclude: ^tests/integration/.*/.*$


### PR DESCRIPTION
Update all hooks to versions still supporting python 3.6
I've not yet looked at what quirks we might run into if updating to run with python 3.7 targeting python 3.6 code (& did not discuss the possibility to drop 3.6 altogether for the code base)