### PR TITLE
chore: drop python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: "3.7"
       - uses: pre-commit/action@v3.0.0
 
   test-dist:
@@ -42,7 +42,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python: "3.6"
           - python: "3.7"
           - python: "3.8"
           - python: "3.9"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,13 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 default_language_version:
-  python: python3.6
+  python: python3.7
 
 exclude: ^src/auditwheel/_vendor/
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.3.0
   hooks:
   - id: check-builtin-literals
   - id: check-added-large-files
@@ -23,13 +23,13 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.30.1
+  rev: v3.1.0
   hooks:
   - id: pyupgrade
-    args: ["--py36-plus"]
+    args: ["--py37-plus"]
 
 - repo: https://github.com/psf/black
-  rev: 22.8.0
+  rev: 22.10.0
   hooks:
   - id: black
 
@@ -37,6 +37,8 @@ repos:
   rev: 5.10.1
   hooks:
   - id: isort
+    args: ["-a", "from __future__ import annotations"]
+    exclude: ^tests/integration/.*/src/.*pyx$
 
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
@@ -44,7 +46,7 @@ repos:
   - id: flake8
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.931
+  rev: v0.982
   hooks:
   - id: mypy
     exclude: ^tests/integration/.*/.*$

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ advised that bundling, like static linking, may implicate copyright concerns.
 Requirements
 ------------
 - OS: Linux
-- Python: 3.6+
+- Python: 3.7+
 - `patchelf <https://github.com/NixOS/patchelf>`_: 0.14+
 
 Only systems that use `ELF
@@ -135,7 +135,7 @@ daemon. These tests will pull a number of docker images if they are not already
 available on your system, but it won't update existing images.
 To update these images manually, run::
 
-    docker pull python:3.6-slim
+    docker pull python:3.7-slim
     docker pull quay.io/pypa/manylinux1_x86_64
     docker pull quay.io/pypa/manylinux2010_x86_64
     docker pull quay.io/pypa/manylinux2014_x86_64

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,17 +1,18 @@
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path
-from typing import List
 
 import nox
 
 nox.options.sessions = ["lint", "test-dist"]
 
-PYTHON_ALL_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
+PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
 RUNNING_CI = "TRAVIS" in os.environ or "GITHUB_ACTIONS" in os.environ
 
 
-@nox.session(python=["3.6"], reuse_venv=True)
+@nox.session(python=["3.7"], reuse_venv=True)
 def lint(session: nox.Session) -> None:
     """
     Run linters on the codebase.
@@ -36,7 +37,7 @@ def coverage(session: nox.Session) -> None:
     )
 
 
-def _docker_images(session: nox.Session) -> List[str]:
+def _docker_images(session: nox.Session) -> list[str]:
     tmp_dir = Path(session.create_tmp())
     script = tmp_dir / "list_images.py"
     images_file = tmp_dir / "images.lst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 # enable version inference
 
 [tool.black]
-target-version = ["py36", "py37", "py38", "py39"]
+target-version = ["py37", "py38", "py39", "py310"]
 extend-exclude = "src/auditwheel/_vendor"
 
 [tool.isort]

--- a/scripts/calculate_symbol_versions.py
+++ b/scripts/calculate_symbol_versions.py
@@ -3,6 +3,8 @@ Calculate symbol_versions for a policy in policy.json by collection
 defined version (.gnu.version_d) from libraries in lib_whitelist.
 This should be run inside a manylinux Docker container.
 """
+from __future__ import annotations
+
 import argparse
 import json
 import os

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifier =
         License :: OSI Approved :: MIT License
         Operating System :: POSIX :: Linux
         Programming Language :: Python :: 3
-        Programming Language :: Python :: 3.6
         Programming Language :: Python :: 3.7
         Programming Language :: Python :: 3.8
         Programming Language :: Python :: 3.9
@@ -32,7 +31,7 @@ install_requires =
 packages = find:
 package_dir =
     =src
-python_requires = >=3.6
+python_requires = >=3.7
 zip_safe = False
 
 [options.package_data]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import setup
 
 extras = {

--- a/src/auditwheel/__main__.py
+++ b/src/auditwheel/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from .main import main

--- a/src/auditwheel/condatools.py
+++ b/src/auditwheel/condatools.py
@@ -1,8 +1,9 @@
 """Context managers like those in wheeltools.py for unpacking
 conda packages.
 """
+from __future__ import annotations
+
 import os
-from typing import List, Optional
 
 from .tmpdirs import InTemporaryDirectory
 from .tools import tarbz2todir
@@ -22,13 +23,13 @@ class InCondaPkg(InTemporaryDirectory):
 class InCondaPkgCtx(InCondaPkg):
     def __init__(self, in_conda_pkg: str) -> None:
         super().__init__(in_conda_pkg)
-        self.path: Optional[str] = None
+        self.path: str | None = None
 
     def __enter__(self):
         self.path = super().__enter__()
         return self
 
-    def iter_files(self) -> List[str]:
+    def iter_files(self) -> list[str]:
         if self.path is None:
             raise ValueError("This function should be called from context manager")
         files = os.path.join(self.path, "info", "files")

--- a/src/auditwheel/elfutils.py
+++ b/src/auditwheel/elfutils.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import os
 from os.path import basename, realpath, relpath
-from typing import Dict, Iterator, List, Optional, Set, Tuple
+from typing import Dict, Iterator, List
 
 from elftools.common.exceptions import ELFError
 from elftools.elf.elffile import ELFFile
@@ -8,7 +10,7 @@ from elftools.elf.elffile import ELFFile
 from .lddtree import parse_ld_paths
 
 
-def elf_read_dt_needed(fn: str) -> List[str]:
+def elf_read_dt_needed(fn: str) -> list[str]:
     needed = []
     with open(fn, "rb") as f:
         elf = ELFFile(f)
@@ -23,7 +25,7 @@ def elf_read_dt_needed(fn: str) -> List[str]:
     return needed
 
 
-def elf_file_filter(paths: Iterator[str]) -> Iterator[Tuple[str, ELFFile]]:
+def elf_file_filter(paths: Iterator[str]) -> Iterator[tuple[str, ELFFile]]:
     """Filter through an iterator of filenames and load up only ELF
     files
     """
@@ -41,7 +43,7 @@ def elf_file_filter(paths: Iterator[str]) -> Iterator[Tuple[str, ELFFile]]:
                 continue
 
 
-def elf_find_versioned_symbols(elf: ELFFile) -> Iterator[Tuple[str, str]]:
+def elf_find_versioned_symbols(elf: ELFFile) -> Iterator[tuple[str, str]]:
     section = elf.get_section_by_name(".gnu.version_r")
 
     if section is not None:
@@ -84,7 +86,7 @@ def elf_references_PyFPE_jbuf(elf: ELFFile) -> bool:
     return False
 
 
-def elf_is_python_extension(fn: str, elf: ELFFile) -> Tuple[bool, Optional[int]]:
+def elf_is_python_extension(fn: str, elf: ELFFile) -> tuple[bool, int | None]:
     modname = basename(fn).split(".", 1)[0]
     module_init_f = {
         "init" + modname: 2,
@@ -108,7 +110,7 @@ def elf_is_python_extension(fn: str, elf: ELFFile) -> Tuple[bool, Optional[int]]
     return False, None
 
 
-def elf_read_rpaths(fn: str) -> Dict[str, List[str]]:
+def elf_read_rpaths(fn: str) -> dict[str, list[str]]:
     result = {"rpaths": [], "runpaths": []}  # type: Dict[str, List[str]]
 
     with open(fn, "rb") as f:
@@ -139,7 +141,7 @@ def is_subdir(path: str, directory: str) -> bool:
     return True
 
 
-def get_undefined_symbols(path: str) -> Set[str]:
+def get_undefined_symbols(path: str) -> set[str]:
     undef_symbols = set()
     with open(path, "rb") as f:
         elf = ELFFile(f)
@@ -153,8 +155,8 @@ def get_undefined_symbols(path: str) -> Set[str]:
 
 
 def filter_undefined_symbols(
-    path: str, symbols: Dict[str, List[str]]
-) -> Dict[str, List[str]]:
+    path: str, symbols: dict[str, list[str]]
+) -> dict[str, list[str]]:
     if not symbols:
         return {}
     undef_symbols = set("*") | get_undefined_symbols(path)

--- a/src/auditwheel/error.py
+++ b/src/auditwheel/error.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class AuditwheelException(Exception):
     pass
 

--- a/src/auditwheel/genericpkgctx.py
+++ b/src/auditwheel/genericpkgctx.py
@@ -1,12 +1,12 @@
-from typing import Optional, Union
+from __future__ import annotations
 
 from .condatools import InCondaPkgCtx
 from .wheeltools import InWheelCtx
 
 
 def InGenericPkgCtx(
-    in_path: str, out_path: Optional[str] = None
-) -> Union[InWheelCtx, InCondaPkgCtx]:
+    in_path: str, out_path: str | None = None
+) -> InWheelCtx | InCondaPkgCtx:
     """Factory that returns a InWheelCtx or InCondaPkgCtx
     context manager depending on the file extension
     """

--- a/src/auditwheel/hashfile.py
+++ b/src/auditwheel/hashfile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 from typing import BinaryIO
 

--- a/src/auditwheel/lddtree.py
+++ b/src/auditwheel/lddtree.py
@@ -12,13 +12,15 @@ files on disk), and we parse the dependency structure as a tree rather than
  a flat list.
 """
 
+from __future__ import annotations
+
 import errno
 import functools
 import glob
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from elftools.elf.elffile import ELFFile
 
@@ -72,13 +74,13 @@ def readlink(path: str, root: str, prefixed: bool = False) -> str:
     return normpath((root + path) if prefixed else path)
 
 
-def dedupe(items: List[str]) -> List[str]:
+def dedupe(items: list[str]) -> list[str]:
     """Remove all duplicates from ``items`` (keeping order)"""
     seen = {}  # type: Dict[str, str]
     return [seen.setdefault(x, x) for x in items if x not in seen]
 
 
-def parse_ld_paths(str_ldpaths: str, path: str, root: str = "") -> List[str]:
+def parse_ld_paths(str_ldpaths: str, path: str, root: str = "") -> list[str]:
     """Parse the colon-delimited list of paths and apply ldso rules to each
 
     Note the special handling as dictated by the ldso:
@@ -113,7 +115,7 @@ def parse_ld_paths(str_ldpaths: str, path: str, root: str = "") -> List[str]:
 
 
 @functools.lru_cache()
-def parse_ld_so_conf(ldso_conf: str, root: str = "/", _first: bool = True) -> List[str]:
+def parse_ld_so_conf(ldso_conf: str, root: str = "/", _first: bool = True) -> list[str]:
     """Load all the paths from a given ldso config file
 
     This should handle comments, whitespace, and "include" statements.
@@ -165,7 +167,7 @@ def parse_ld_so_conf(ldso_conf: str, root: str = "/", _first: bool = True) -> Li
 
 
 @functools.lru_cache()
-def load_ld_paths(root: str = "/", prefix: str = "") -> Dict[str, List[str]]:
+def load_ld_paths(root: str = "/", prefix: str = "") -> dict[str, list[str]]:
     """Load linker paths from common locations
 
     This parses the ld.so.conf and LD_LIBRARY_PATH env var.
@@ -258,8 +260,8 @@ def compatible_elfs(elf1: ELFFile, elf2: ELFFile) -> bool:
 
 
 def find_lib(
-    elf: ELFFile, lib: str, ldpaths: List[str], root: str = "/"
-) -> Tuple[Optional[str], Optional[str]]:
+    elf: ELFFile, lib: str, ldpaths: list[str], root: str = "/"
+) -> tuple[str | None, str | None]:
     """Try to locate a ``lib`` that is compatible to ``elf`` in the given
     ``ldpaths``
 
@@ -296,11 +298,11 @@ def lddtree(
     path: str,
     root: str = "/",
     prefix: str = "",
-    ldpaths: Optional[Dict[str, List[str]]] = None,
-    display: Optional[str] = None,
+    ldpaths: dict[str, list[str]] | None = None,
+    display: str | None = None,
     _first: bool = True,
-    _all_libs: Dict = {},
-) -> Dict:
+    _all_libs: dict = {},
+) -> dict:
     """Parse the ELF dependency tree of the specified file
 
     Parameters

--- a/src/auditwheel/libc.py
+++ b/src/auditwheel/libc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from enum import IntEnum
 

--- a/src/auditwheel/main.py
+++ b/src/auditwheel/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import logging
 import os
@@ -9,14 +11,12 @@ if sys.version_info[:2] >= (3, 8):
 else:
     import importlib_metadata as metadata
 
-from typing import Optional
-
 import auditwheel
 
 from . import main_addtag, main_lddtree, main_repair, main_show
 
 
-def main() -> Optional[int]:
+def main() -> int | None:
     if sys.platform != "linux":
         print("Error: This tool only supports Linux")
         return 1

--- a/src/auditwheel/main_addtag.py
+++ b/src/auditwheel/main_addtag.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from os.path import abspath, basename, exists, join
 

--- a/src/auditwheel/main_lddtree.py
+++ b/src/auditwheel/main_lddtree.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 logger = logging.getLogger(__name__)

--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import logging
 from os.path import abspath, basename, exists, isfile

--- a/src/auditwheel/main_show.py
+++ b/src/auditwheel/main_show.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from collections import OrderedDict
 

--- a/src/auditwheel/musllinux.py
+++ b/src/auditwheel/musllinux.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import pathlib
 import re

--- a/src/auditwheel/patcher.py
+++ b/src/auditwheel/patcher.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import re
 from distutils.spawn import find_executable
 from itertools import chain
 from subprocess import CalledProcessError, check_call, check_output
-from typing import Tuple
 
 
 class ElfPatcher:
-    def replace_needed(self, file_name: str, *old_new_pairs: Tuple[str, str]) -> None:
+    def replace_needed(self, file_name: str, *old_new_pairs: tuple[str, str]) -> None:
         raise NotImplementedError
 
     def set_soname(self, file_name: str, new_so_name: str) -> None:
@@ -43,7 +44,7 @@ class Patchelf(ElfPatcher):
     def __init__(self) -> None:
         _verify_patchelf()
 
-    def replace_needed(self, file_name: str, *old_new_pairs: Tuple[str, str]) -> None:
+    def replace_needed(self, file_name: str, *old_new_pairs: tuple[str, str]) -> None:
         check_call(
             [
                 "patchelf",

--- a/src/auditwheel/policy/__init__.py
+++ b/src/auditwheel/policy/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import platform as _platform_module
@@ -5,7 +7,6 @@ import sys
 from collections import defaultdict
 from os.path import abspath, dirname, join
 from pathlib import Path
-from typing import Dict, List, Optional, Set
 
 from ..libc import Libc, get_libc
 from ..musllinux import find_musl_libc, get_musl_version
@@ -31,8 +32,8 @@ _LIBC = get_libc()
 
 
 def _validate_pep600_compliance(policies) -> None:
-    symbol_versions: Dict[str, Dict[str, Set[str]]] = {}
-    lib_whitelist: Set[str] = set()
+    symbol_versions: dict[str, dict[str, set[str]]] = {}
+    lib_whitelist: set[str] = set()
     for policy in sorted(policies, key=lambda x: x["priority"], reverse=True):
         if policy["name"] == "linux":
             continue
@@ -131,7 +132,7 @@ def _load_policy_schema():
     return schema
 
 
-def get_policy_by_name(name: str) -> Optional[Dict]:
+def get_policy_by_name(name: str) -> dict | None:
     matches = [p for p in _POLICIES if p["name"] == name or name in p["aliases"]]
     if len(matches) == 0:
         return None
@@ -140,7 +141,7 @@ def get_policy_by_name(name: str) -> Optional[Dict]:
     return matches[0]
 
 
-def get_policy_name(priority: int) -> Optional[str]:
+def get_policy_name(priority: int) -> str | None:
     matches = [p["name"] for p in _POLICIES if p["priority"] == priority]
     if len(matches) == 0:
         return None
@@ -149,12 +150,12 @@ def get_policy_name(priority: int) -> Optional[str]:
     return matches[0]
 
 
-def get_priority_by_name(name: str) -> Optional[int]:
+def get_priority_by_name(name: str) -> int | None:
     policy = get_policy_by_name(name)
     return None if policy is None else policy["priority"]
 
 
-def get_replace_platforms(name: str) -> List[str]:
+def get_replace_platforms(name: str) -> list[str]:
     """Extract platform tag replacement rules from policy
 
     >>> get_replace_platforms('linux_x86_64')

--- a/src/auditwheel/policy/external_references.py
+++ b/src/auditwheel/policy/external_references.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import re
 from typing import Any, Dict, Generator, Set
@@ -9,12 +11,12 @@ log = logging.getLogger(__name__)
 LIBPYTHON_RE = re.compile(r"^libpython\d\.\dm?.so(.\d)*$")
 
 
-def lddtree_external_references(lddtree: Dict, wheel_path: str) -> Dict:
+def lddtree_external_references(lddtree: dict, wheel_path: str) -> dict:
     # XXX: Document the lddtree structure, or put it in something
     # more stable than a big nested dict
     policies = load_policies()
 
-    def filter_libs(libs: Set[str], whitelist: Set[str]) -> Generator[str, None, None]:
+    def filter_libs(libs: set[str], whitelist: set[str]) -> Generator[str, None, None]:
         for lib in libs:
             if "ld-linux" in lib or lib in ["ld64.so.2", "ld64.so.1"]:
                 # always exclude ELF dynamic linker/loader
@@ -30,7 +32,7 @@ def lddtree_external_references(lddtree: Dict, wheel_path: str) -> Dict:
                 continue
             yield lib
 
-    def get_req_external(libs: Set[str], whitelist: Set[str]) -> Set[str]:
+    def get_req_external(libs: set[str], whitelist: set[str]) -> set[str]:
         # get all the required external libraries
         libs = libs.copy()
         reqs = set()

--- a/src/auditwheel/policy/versioned_symbols.py
+++ b/src/auditwheel/policy/versioned_symbols.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import Dict, List, Set
 
@@ -6,9 +8,9 @@ from . import load_policies
 log = logging.getLogger(__name__)
 
 
-def versioned_symbols_policy(versioned_symbols: Dict[str, Set[str]]) -> int:
+def versioned_symbols_policy(versioned_symbols: dict[str, set[str]]) -> int:
     def policy_is_satisfied(
-        policy_name: str, policy_sym_vers: Dict[str, Set[str]]
+        policy_name: str, policy_sym_vers: dict[str, set[str]]
     ) -> bool:
         policy_satisfied = True
         for name in set(required_vers) & set(policy_sym_vers):

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 import logging
 import os
@@ -9,7 +11,7 @@ from collections import OrderedDict
 from os.path import abspath, basename, dirname, exists, isabs
 from os.path import join as pjoin
 from subprocess import check_call
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Tuple
 
 from auditwheel.patcher import ElfPatcher
 
@@ -32,14 +34,14 @@ WHEEL_INFO_RE = re.compile(
 
 def repair_wheel(
     wheel_path: str,
-    abis: List[str],
+    abis: list[str],
     lib_sdir: str,
     out_dir: str,
     update_tags: bool,
     patcher: ElfPatcher,
-    exclude: List[str],
+    exclude: list[str],
     strip: bool = False,
-) -> Optional[str]:
+) -> str | None:
 
     external_refs_by_fn = get_wheel_elfdata(wheel_path)[1]
 
@@ -126,7 +128,7 @@ def strip_symbols(libraries: Iterable[str]) -> None:
         check_call(["strip", "-s", lib])
 
 
-def copylib(src_path: str, dest_dir: str, patcher: ElfPatcher) -> Tuple[str, str]:
+def copylib(src_path: str, dest_dir: str, patcher: ElfPatcher) -> tuple[str, str]:
     """Graft a shared library from the system into the wheel and update the
     relevant links.
 

--- a/src/auditwheel/tmpdirs.py
+++ b/src/auditwheel/tmpdirs.py
@@ -1,9 +1,10 @@
 """ Contexts for *with* statement providing temporary directories
 """
+from __future__ import annotations
+
 import os
 from tempfile import TemporaryDirectory
 from types import TracebackType
-from typing import Optional, Type
 
 
 class InTemporaryDirectory:
@@ -37,9 +38,9 @@ class InTemporaryDirectory:
 
     def __exit__(
         self,
-        exc: Optional[Type[BaseException]],
-        value: Optional[BaseException],
-        tb: Optional[TracebackType],
+        exc: type[BaseException] | None,
+        value: BaseException | None,
+        tb: TracebackType | None,
     ) -> None:
         os.chdir(self._pwd)
         return self._tmpdir.__exit__(exc, value, tb)
@@ -69,7 +70,7 @@ class InGivenDirectory:
     again.
     """
 
-    def __init__(self, path: Optional[str] = None) -> None:
+    def __init__(self, path: str | None = None) -> None:
         """Initialize directory context manager
 
         Parameters
@@ -91,8 +92,8 @@ class InGivenDirectory:
 
     def __exit__(
         self,
-        exc: Optional[Type[BaseException]],
-        value: Optional[BaseException],
-        tb: Optional[TracebackType],
+        exc: type[BaseException] | None,
+        value: BaseException | None,
+        tb: TracebackType | None,
     ) -> None:
         os.chdir(self._pwd)

--- a/src/auditwheel/tools.py
+++ b/src/auditwheel/tools.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
 import argparse
 import os
 import subprocess
 import zipfile
 from datetime import datetime, timezone
-from typing import Any, Iterable, List, Optional
+from typing import Any, Iterable
 
 
-def unique_by_index(sequence: Iterable[Any]) -> List[Any]:
+def unique_by_index(sequence: Iterable[Any]) -> list[Any]:
     """unique elements in `sequence` in the order in which they occur
 
     Parameters
@@ -50,7 +52,7 @@ def zip2dir(zip_fname: str, out_dir: str) -> None:
                 os.chmod(extracted_path, attr)
 
 
-def dir2zip(in_dir: str, zip_fname: str, date_time: Optional[datetime] = None) -> None:
+def dir2zip(in_dir: str, zip_fname: str, date_time: datetime | None = None) -> None:
     """Make a zip file `zip_fname` with contents of directory `in_dir`
 
     The recorded filenames are relative to `in_dir`, so doing a standard zip

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import itertools
 import json
@@ -165,14 +167,14 @@ def get_wheel_elfdata(wheel_fn: str):
     )
 
 
-def get_external_libs(external_refs) -> Dict[str, str]:
+def get_external_libs(external_refs) -> dict[str, str]:
     """Get external library dependencies for all policies excluding the default
     linux policy
     :param external_refs: external references for all policies
     :return: {realpath: soname} e.g.
     {'/path/to/external_ref.so.1.2.3': 'external_ref.so.1'}
     """
-    result: Dict[str, str] = {}
+    result: dict[str, str] = {}
     for policy in external_refs.values():
         # linux tag (priority 0) has no white-list, do not analyze it
         if policy["priority"] == 0:

--- a/src/auditwheel/wheeltools.py
+++ b/src/auditwheel/wheeltools.py
@@ -3,6 +3,8 @@
 Tools that aren't specific to delocation
 """
 
+from __future__ import annotations
+
 import csv
 import glob
 import hashlib
@@ -17,7 +19,7 @@ from os.path import relpath
 from os.path import sep as psep
 from os.path import splitext
 from types import TracebackType
-from typing import Generator, Iterable, List, Optional, Type
+from typing import Generator, Iterable
 
 from ._vendor.wheel.pkginfo import read_pkg_info, write_pkg_info
 from ._vendor.wheel.wheelfile import WHEEL_INFO_RE
@@ -101,7 +103,7 @@ class InWheel(InTemporaryDirectory):
     pack stuff up for you.
     """
 
-    def __init__(self, in_wheel: str, out_wheel: Optional[str] = None) -> None:
+    def __init__(self, in_wheel: str, out_wheel: str | None = None) -> None:
         """Initialize in-wheel context manager
 
         Parameters
@@ -122,9 +124,9 @@ class InWheel(InTemporaryDirectory):
 
     def __exit__(
         self,
-        exc: Optional[Type[BaseException]],
-        value: Optional[BaseException],
-        tb: Optional[TracebackType],
+        exc: type[BaseException] | None,
+        value: BaseException | None,
+        tb: TracebackType | None,
     ) -> None:
         if self.out_wheel is not None:
             rewrite_record(self.name)
@@ -152,7 +154,7 @@ class InWheelCtx(InWheel):
     ``wheel_path``.
     """
 
-    def __init__(self, in_wheel: str, out_wheel: Optional[str] = None) -> None:
+    def __init__(self, in_wheel: str, out_wheel: str | None = None) -> None:
         """Init in-wheel context manager returning self from enter
 
         Parameters
@@ -186,7 +188,7 @@ class InWheelCtx(InWheel):
 
 
 def add_platforms(
-    wheel_ctx: InWheelCtx, platforms: List[str], remove_platforms: Iterable[str] = ()
+    wheel_ctx: InWheelCtx, platforms: list[str], remove_platforms: Iterable[str] = ()
 ) -> str:
     """Add platform tags `platforms` to a wheel
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 collect_ignore = ["quick_check_numpy.py"]

--- a/tests/integration/internal_rpath/setup.py
+++ b/tests/integration/internal_rpath/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension, find_packages, setup
 
 package_name = "internal_rpath"

--- a/tests/integration/multiple_top_level/setup.py
+++ b/tests/integration/multiple_top_level/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension, find_packages, setup
 
 setup(

--- a/tests/integration/nonpy_rpath/nonpy_rpath/__init__.py
+++ b/tests/integration/nonpy_rpath/nonpy_rpath/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ._nonpy_rpath import crypt_something
 
 __all__ = ["crypt_something"]

--- a/tests/integration/nonpy_rpath/setup.py
+++ b/tests/integration/nonpy_rpath/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import setuptools.command.build_ext

--- a/tests/integration/quick_check_numpy.py
+++ b/tests/integration/quick_check_numpy.py
@@ -1,5 +1,7 @@
 # Sample numpy program that requires some BLAS and LAPACK routines to work
 # properly
+from __future__ import annotations
+
 import numpy as np
 
 rng = np.random.RandomState(0)

--- a/tests/integration/sample_extension/setup.py
+++ b/tests/integration/sample_extension/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from Cython.Build import cythonize
 from setuptools import setup
 

--- a/tests/integration/test_addtag.py
+++ b/tests/integration/test_addtag.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from unittest.mock import Mock
 

--- a/tests/integration/test_bundled_wheels.py
+++ b/tests/integration/test_bundled_wheels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import platform
 import subprocess
 import sys

--- a/tests/integration/test_glibcxx_3_4_25/setup.py
+++ b/tests/integration/test_glibcxx_3_4_25/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension, setup
 
 setup(

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import glob
 import io
 import logging
@@ -80,7 +82,6 @@ PATH_DIRS = [
 PATH = {k: ":".join(PATH_DIRS).format(devtoolset=v) for k, v in DEVTOOLSET.items()}
 WHEEL_CACHE_FOLDER = op.expanduser("~/.cache/auditwheel_tests")
 NUMPY_VERSION_MAP = {
-    "36": "1.19.2",
     "37": "1.19.2",
     "38": "1.19.2",
     "39": "1.19.2",
@@ -805,7 +806,7 @@ class TestManylinux(Anylinux):
         Plus up-to-date pip, setuptools and pytest-cov
         """
         policy = request.param
-        if policy == "manylinux_2_5" and PYTHON_ABI_MAJ_MIN in {"310"}:
+        if policy == "manylinux_2_5" and PYTHON_ABI_MAJ_MIN not in {"37", "38", "39"}:
             pytest.skip(f"manylinux_2_5 images do not support cp{PYTHON_ABI_MAJ_MIN}")
         base = MANYLINUX_IMAGES[policy]
         env = {"PATH": PATH[policy]}

--- a/tests/integration/test_nonplatform_wheel.py
+++ b/tests/integration/test_nonplatform_wheel.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import subprocess
 
@@ -12,7 +14,7 @@ def test_non_platform_wheel_repair(mode):
     proc = subprocess.run(
         ["auditwheel", mode, str(wheel)],
         stderr=subprocess.PIPE,
-        universal_newlines=True,
+        text=True,
     )
     assert proc.returncode == 1
     assert "This does not look like a platform wheel" in proc.stderr

--- a/tests/integration/test_policy_files.py
+++ b/tests/integration/test_policy_files.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from jsonschema import validate
 
 from auditwheel.policy import (

--- a/tests/integration/testdependencies/setup.py
+++ b/tests/integration/testdependencies/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 from os import getenv, path
 

--- a/tests/integration/testpackage/setup.py
+++ b/tests/integration/testpackage/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 
 from setuptools import setup

--- a/tests/integration/testpackage/testpackage/__init__.py
+++ b/tests/integration/testpackage/testpackage/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 
 import pkg_resources

--- a/tests/integration/testrpath/setup.py
+++ b/tests/integration/testrpath/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import subprocess
 

--- a/tests/integration/testsimple/setup.py
+++ b/tests/integration/testsimple/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension, setup
 
 setup(

--- a/tests/integration/testzlib/setup.py
+++ b/tests/integration/testzlib/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension, setup
 
 define_macros = [("_GNU_SOURCE", None)]

--- a/tests/unit/test_condatools.py
+++ b/tests/unit/test_condatools.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock, patch
 
 from auditwheel.condatools import InCondaPkg, InCondaPkgCtx

--- a/tests/unit/test_elfpatcher.py
+++ b/tests/unit/test_elfpatcher.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from subprocess import CalledProcessError
 from unittest.mock import call, patch
 

--- a/tests/unit/test_elfutils.py
+++ b/tests/unit/test_elfutils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import Mock, patch
 
 import pytest

--- a/tests/unit/test_hashfile.py
+++ b/tests/unit/test_hashfile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from io import BytesIO
 
 from auditwheel.hashfile import hashfile

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/tests/unit/test_musllinux.py
+++ b/tests/unit/test_musllinux.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 from unittest.mock import patch
 

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/unit/test_repair.py
+++ b/tests/unit/test_repair.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from unittest.mock import call, patch
 

--- a/tests/unit/test_tmpdirs.py
+++ b/tests/unit/test_tmpdirs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from auditwheel.tmpdirs import InGivenDirectory, InTemporaryDirectory

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import lzma
 from pathlib import Path

--- a/tests/unit/test_wheel_abi.py
+++ b/tests/unit/test_wheel_abi.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import pretend


### PR DESCRIPTION
Drop python 3.6, it's been EOL for almost 1 year.
It doesn't prevent repairing 3.6 wheels (or older)