### PR TITLE
Add support for `fnmatch` patterns in --exclude args

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
       - uses: pre-commit/action@v3.0.0
 
   test-dist:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,53 +2,53 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 default_language_version:
-  python: python3.7
+  python: python3.11
 
 exclude: ^src/auditwheel/_vendor/
 
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
-  hooks:
-  - id: check-builtin-literals
-  - id: check-added-large-files
-  - id: check-case-conflict
-  - id: check-json
-  - id: check-toml
-  - id: check-yaml
-  - id: debug-statements
-  - id: end-of-file-fixer
-    exclude: ^cache/
-  - id: forbid-new-submodules
-  - id: trailing-whitespace
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-builtin-literals
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+        exclude: ^cache/
+      - id: forbid-new-submodules
+      - id: trailing-whitespace
 
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.2.2
-  hooks:
-  - id: pyupgrade
-    args: ["--py37-plus"]
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.2.2
+    hooks:
+      - id: pyupgrade
+        args: ["--py37-plus"]
 
-- repo: https://github.com/psf/black
-  rev: 22.10.0
-  hooks:
-  - id: black
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black
 
-- repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
-  hooks:
-  - id: isort
-    args: ["-a", "from __future__ import annotations"]
-    exclude: ^tests/integration/.*/src/.*pyx$
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["-a", "from __future__ import annotations"]
+        exclude: ^tests/integration/.*/src/.*pyx$
 
-- repo: https://github.com/PyCQA/flake8
-  rev: 5.0.4
-  hooks:
-  - id: flake8
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8
 
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.991
-  hooks:
-  - id: mypy
-    exclude: ^tests/integration/.*/.*$
-    additional_dependencies:
-      - types-requests
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.991
+    hooks:
+      - id: mypy
+        exclude: ^tests/integration/.*/.*$
+        additional_dependencies:
+          - types-requests

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fnmatch
 import itertools
 import logging
 import os
@@ -73,8 +74,7 @@ def repair_wheel(
             ext_libs = v[abis[0]]["libs"]  # type: Dict[str, str]
             replacements = []  # type: List[Tuple[str, str]]
             for soname, src_path in ext_libs.items():
-
-                if soname in exclude:
+                if any(fnmatch.fnmatch(soname, e) for e in exclude):
                     logger.info(f"Excluding {soname}")
                     continue
 

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -66,7 +66,7 @@ DEVTOOLSET = {
     "manylinux_2_12": "devtoolset-8",
     "manylinux_2_17": "devtoolset-10",
     "manylinux_2_24": "devtoolset-not-present",
-    "manylinux_2_28": "gcc-toolset-11",
+    "manylinux_2_28": "gcc-toolset-12",
     "musllinux_1_1": "devtoolset-not-present",
 }
 PATH_DIRS = [


### PR DESCRIPTION
Context: need to build a wheel where I exclude `libarrow` libraries. I'd love to avoid changing the build script everytime arrow is updated. Using `libarrow*` would make the repair script more future proof. 

The PR also integrates a couple of commit that I needed to add to make checks and test work. 