### PR TITLE
Filter libpythonXY for greater than single digits

### DIFF
--- a/src/auditwheel/policy/external_references.py
+++ b/src/auditwheel/policy/external_references.py
@@ -8,7 +8,7 @@ from ..elfutils import filter_undefined_symbols, is_subdir
 from . import load_policies
 
 log = logging.getLogger(__name__)
-LIBPYTHON_RE = re.compile(r"^libpython\d\.\dm?.so(.\d)*$")
+LIBPYTHON_RE = re.compile(r"^libpython\d+\.\d+m?.so(.\d)*$")
 
 
 def lddtree_external_references(lddtree: dict, wheel_path: str) -> dict:

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -6,6 +6,7 @@ import pytest
 
 from auditwheel.policy import (
     _validate_pep600_compliance,
+    lddtree_external_references,
     get_arch_name,
     get_policy_name,
     get_priority_by_name,
@@ -202,3 +203,32 @@ class TestPolicyAccess:
     def test_get_by_name_duplicate(self):
         with pytest.raises(RuntimeError):
             get_priority_by_name("duplicate")
+
+
+class TestLddTreeExternalReferences:
+    """Tests for lddtree_external_references."""
+
+    def test_filter_libs(self):
+        """Test the nested filter_libs function."""
+        filtered_libs = [
+            "ld-linux-x86_64.so.1",
+            "ld64.so.1",
+            "ld64.so.2",
+            "libpython3.7m.so.1.0",
+            "libpython3.9.so.1.0",
+            "libpython3.10.so.1.0",
+            "libpython999.999.so.1.0",
+        ]
+        unfiltered_libs = ["libfoo.so.1.0", "libbar.so.999.999.999"]
+        libs = filtered_libs + unfiltered_libs
+
+        lddtree = {
+            "realpath": "/path/to/lib",
+            "needed": libs,
+            "libs": {lib: {"needed": [], "realpath": "/path/to/lib"} for lib in libs},
+        }
+        full_external_refs = lddtree_external_references(lddtree, "/path/to/wheel")
+
+        # Assert that each policy only has the unfiltered libs.
+        for policy in full_external_refs:
+            assert set(full_external_refs[policy]["libs"]) == set(unfiltered_libs)

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -6,11 +6,11 @@ import pytest
 
 from auditwheel.policy import (
     _validate_pep600_compliance,
-    lddtree_external_references,
     get_arch_name,
     get_policy_name,
     get_priority_by_name,
     get_replace_platforms,
+    lddtree_external_references,
 )
 
 


### PR DESCRIPTION
* Fixed regex for filtering >1 digit for X and Y in libpythonXY
  * I doubt Python 10 is coming anytime soon, but it would work now! 
* Added tests for `filter_libs` in `lddtree_external_references`

Fixes #418.