### PR TITLE
Added '-t/--set-tags' option to 'addtag' subcommand

### DIFF
--- a/tests/integration/test_addtag.py
+++ b/tests/integration/test_addtag.py
@@ -11,6 +11,27 @@ HERE = Path(__file__).parent.resolve()
 def test_smoke(tmpdir):
     """Simple test to exercise the 'addtag' code path"""
     args = Mock(
+        TAGS=None,
+        WHEEL_FILE=str(HERE / "cffi-1.5.0-cp27-none-linux_x86_64.whl"),
+        WHEEL_DIR=str(tmpdir / "wheelhouse/"),
+    )
+    execute(args, None)
+
+
+def test_addtag_single(tmpdir):
+    """Simple test to exercise the 'addtag' code path"""
+    args = Mock(
+        TAGS=["tag1"],
+        WHEEL_FILE=str(HERE / "cffi-1.5.0-cp27-none-linux_x86_64.whl"),
+        WHEEL_DIR=str(tmpdir / "wheelhouse/"),
+    )
+    execute(args, None)
+
+
+def test_addtag_multiple(tmpdir):
+    """Simple test to exercise the 'addtag' code path"""
+    args = Mock(
+        TAGS=["tag1", "tag2"],
         WHEEL_FILE=str(HERE / "cffi-1.5.0-cp27-none-linux_x86_64.whl"),
         WHEEL_DIR=str(tmpdir / "wheelhouse/"),
     )


### PR DESCRIPTION
Main idea for this modification is to either "repair" armv7l wheels to armv6l, or to add both tags to the wheel.
Raspberry Pi usually report platform as armv7l but their toolchain defaults to armv6l compatible builds. If author of the wheel is sure that is the case, they may just make a copy/tweak to the built wheel to be marked as compatible for both.

Could also be spun off as a separate command.

Side observation, `add_platforms` does not act correct when a tag is specified as to be removed + to be added. In that case, remove takes precedence, but not in the filename. This makes the WHEEL file contain different tag specifiers than resulting wheel filename.