### PR TITLE
Remove OrderedDict

### DIFF
--- a/src/auditwheel/main_show.py
+++ b/src/auditwheel/main_show.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from collections import OrderedDict
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +100,7 @@ def execute(args, p):
         printp("The wheel requires no external shared libraries! :)")
     else:
         printp("The following external shared libraries are required " "by the wheel:")
-        print(json.dumps(OrderedDict(sorted(libs.items())), indent=4))
+        print(json.dumps(dict(sorted(libs.items())), indent=4))
 
     for p in sorted(load_policies(), key=lambda p: p["priority"]):
         if p["priority"] > get_priority_by_name(winfo.overall_tag):

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -7,7 +7,6 @@ import platform
 import re
 import shutil
 import stat
-from collections import OrderedDict
 from os.path import abspath, basename, dirname, exists, isabs
 from os.path import join as pjoin
 from subprocess import check_call
@@ -191,8 +190,7 @@ def append_rpath_within_wheel(
     old_rpaths = patcher.get_rpath(lib_name)
     rpaths = filter(is_valid_rpath, old_rpaths.split(":"))
     # Remove duplicates while preserving ordering
-    # Fake an OrderedSet using OrderedDict
-    rpath_set = OrderedDict([(old_rpath, "") for old_rpath in rpaths])
+    rpath_set = {old_rpath: "" for old_rpath in rpaths}
     rpath_set[rpath] = ""
 
     patcher.set_rpath(lib_name, ":".join(rpath_set))

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -190,6 +190,7 @@ def append_rpath_within_wheel(
     old_rpaths = patcher.get_rpath(lib_name)
     rpaths = filter(is_valid_rpath, old_rpaths.split(":"))
     # Remove duplicates while preserving ordering
+    # Fake an OrderedSet using a dict (ordered in python 3.7+)
     rpath_set = {old_rpath: "" for old_rpath in rpaths}
     rpath_set[rpath] = ""
 


### PR DESCRIPTION
Since Python 3.7 the insertion order to `dict` has been preserved, thus OrderedDict is no longer necessary.

Note that `src/auditwheel/_vendor/wheel/wheelfile.py` uses OrderedDict, but is not modified. This was modified upstream from https://github.com/pypa/wheel/pull/561