### PR TITLE
chore: use openblas on manylinux_2_28

### DIFF
--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -208,7 +208,7 @@ def build_numpy(container, policy, output_dir):
     else:
         docker_exec(container, "yum install -y atlas atlas-devel")
 
-    if False and op.exists(op.join(WHEEL_CACHE_FOLDER, policy, ORIGINAL_NUMPY_WHEEL)):
+    if op.exists(op.join(WHEEL_CACHE_FOLDER, policy, ORIGINAL_NUMPY_WHEEL)):
         # If numpy has already been built and put in cache, let's reuse this.
         shutil.copy2(
             op.join(WHEEL_CACHE_FOLDER, policy, ORIGINAL_NUMPY_WHEEL),

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -203,6 +203,8 @@ def build_numpy(container, policy, output_dir):
 
     if policy.startswith("musllinux_"):
         docker_exec(container, "apk add openblas-dev")
+    elif policy.startswith("manylinux_2_28_"):
+        docker_exec(container, "dnf install -y openblas-devel")
     else:
         docker_exec(container, "yum install -y atlas atlas-devel")
 
@@ -264,7 +266,7 @@ class Anylinux:
         policy, tag, manylinux_ctr = any_manylinux_container
 
         # First build numpy from source as a naive linux wheel that is tied
-        # to system libraries (atlas, libgfortran...)
+        # to system libraries (blas, libgfortran...)
         orig_wheel = build_numpy(manylinux_ctr, policy, io_folder)
         assert orig_wheel == ORIGINAL_NUMPY_WHEEL
         assert "manylinux" not in orig_wheel

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -208,7 +208,7 @@ def build_numpy(container, policy, output_dir):
     else:
         docker_exec(container, "yum install -y atlas atlas-devel")
 
-    if op.exists(op.join(WHEEL_CACHE_FOLDER, policy, ORIGINAL_NUMPY_WHEEL)):
+    if False and op.exists(op.join(WHEEL_CACHE_FOLDER, policy, ORIGINAL_NUMPY_WHEEL)):
         # If numpy has already been built and put in cache, let's reuse this.
         shutil.copy2(
             op.join(WHEEL_CACHE_FOLDER, policy, ORIGINAL_NUMPY_WHEEL),


### PR DESCRIPTION
Prepare for python 3.12, numpy will require OpenBLAS rather than atlas.
Furthermore, atlas fails randomly on travis-ci on manylinux_2_28 with a `assertion !pthread_create(&thr->thrH, &attr, rout, arg) failed, line 119 of file /builddir/build/BUILD/ATLAS/s390x_base/..//src/threads/ATL_thread_start.c` message so this should take care of that as well.