### PR TITLE
Fix rpath setting on external libraries

### DIFF
--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -162,7 +162,7 @@ def copylib(src_path: str, dest_dir: str, patcher: ElfPatcher) -> tuple[str, str
     patcher.set_soname(dest_path, new_soname)
 
     if any(itertools.chain(rpaths["rpaths"], rpaths["runpaths"])):
-        new_rpath = pjoin('$ORIGIN', os.path.relpath(dest_dir, dirname(dest_path)))
+        new_rpath = pjoin("$ORIGIN", os.path.relpath(dest_dir, dirname(dest_path)))
         patcher.set_rpath(dest_path, new_rpath)
 
     return new_soname, dest_path

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -162,7 +162,8 @@ def copylib(src_path: str, dest_dir: str, patcher: ElfPatcher) -> tuple[str, str
     patcher.set_soname(dest_path, new_soname)
 
     if any(itertools.chain(rpaths["rpaths"], rpaths["runpaths"])):
-        patcher.set_rpath(dest_path, dest_dir)
+        new_rpath = pjoin('$ORIGIN', os.path.relpath(dest_dir, dirname(dest_path)))
+        patcher.set_rpath(dest_path, new_rpath)
 
     return new_soname, dest_path
 


### PR DESCRIPTION
External libraries will be copied to sdir during the process. If the external library contains rpath, rpath will be removed and reset.

Since commit a9b4794d688dba7cbfdee74ab27bc7d5c3c4c390, rpath will be set to the `dest_dir` if an external library originally contains rpath. It is quite weird and will let the loader (on Android) gives a warning message.

Original library:
```
$ readelf -d libopenblas.so
 0x000000000000001d (RUNPATH)            Library runpath: [/data/data/com.termux/files/usr/lib]
```

Library after processing:
```
$ readelf -d libopenblas-2e48b161.so
 0x000000000000001d (RUNPATH)            Library runpath: [numpy-libs]
```

The intended behavior:
```
$ readelf -d libopenblas-xxxxxx.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/.]
```
