### PR TITLE
chore: drop python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python: "3.7"
           - python: "3.8"
           - python: "3.9"
           - python: "3.10"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
   rev: v3.13.0
   hooks:
   - id: pyupgrade
-    args: ["--py37-plus"]
+    args: ["--py38-plus"]
 
 - repo: https://github.com/psf/black
   rev: 23.9.1

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ advised that bundling, like static linking, may implicate copyright concerns.
 Requirements
 ------------
 - OS: Linux
-- Python: 3.7+
+- Python: 3.8+
 - `patchelf <https://github.com/NixOS/patchelf>`_: 0.14+
 
 Only systems that use `ELF
@@ -135,7 +135,7 @@ daemon. These tests will pull a number of docker images if they are not already
 available on your system, but it won't update existing images.
 To update these images manually, run::
 
-    docker pull python:3.7-slim
+    docker pull python:3.8-slim
     docker pull quay.io/pypa/manylinux1_x86_64
     docker pull quay.io/pypa/manylinux2010_x86_64
     docker pull quay.io/pypa/manylinux2014_x86_64

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ import nox
 
 nox.options.sessions = ["lint", "test-dist"]
 
-PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 RUNNING_CI = "TRAVIS" in os.environ or "GITHUB_ACTIONS" in os.environ
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,11 @@ build-backend = "setuptools.build_meta"
 # enable version inference
 
 [tool.black]
-target-version = ["py37", "py38", "py39", "py310", "py311", "py312"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 extend-exclude = "src/auditwheel/_vendor"
 
 [tool.isort]
-py_version = 37
+py_version = 38
 profile = "black"
 extend_skip_glob = "src/auditwheel/_vendor/**/*.py"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifier =
         License :: OSI Approved :: MIT License
         Operating System :: POSIX :: Linux
         Programming Language :: Python :: 3
-        Programming Language :: Python :: 3.7
         Programming Language :: Python :: 3.8
         Programming Language :: Python :: 3.9
         Programming Language :: Python :: 3.10
@@ -30,11 +29,10 @@ include_package_data = True
 install_requires =
     packaging>=20.9
     pyelftools>=0.24
-    importlib_metadata; python_version < "3.8"
 packages = find:
 package_dir =
     =src
-python_requires = >=3.7
+python_requires = >=3.8
 zip_safe = False
 
 [options.package_data]

--- a/src/auditwheel/lddtree.py
+++ b/src/auditwheel/lddtree.py
@@ -114,7 +114,7 @@ def parse_ld_paths(str_ldpaths: str, path: str, root: str = "") -> list[str]:
     return [p for p in dedupe(ldpaths) if os.path.isdir(p)]
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def parse_ld_so_conf(ldso_conf: str, root: str = "/", _first: bool = True) -> list[str]:
     """Load all the paths from a given ldso config file
 
@@ -166,7 +166,7 @@ def parse_ld_so_conf(ldso_conf: str, root: str = "/", _first: bool = True) -> li
     return paths
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def load_ld_paths(root: str = "/", prefix: str = "") -> dict[str, list[str]]:
     """Load linker paths from common locations
 

--- a/src/auditwheel/main.py
+++ b/src/auditwheel/main.py
@@ -5,11 +5,7 @@ import logging
 import os
 import pathlib
 import sys
-
-if sys.version_info[:2] >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
+from importlib import metadata
 
 import auditwheel
 

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -58,7 +58,7 @@ class NonPlatformWheel(WheelAbiError):
     )
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def get_wheel_elfdata(wheel_fn: str):
     full_elftree = {}
     nonpy_elftree = {}

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -80,7 +80,6 @@ PATH_DIRS = [
 PATH = {k: ":".join(PATH_DIRS).format(devtoolset=v) for k, v in DEVTOOLSET.items()}
 WHEEL_CACHE_FOLDER = op.expanduser("~/.cache/auditwheel_tests")
 NUMPY_VERSION_MAP = {
-    "37": "1.21.4",
     "38": "1.21.4",
     "39": "1.21.4",
     "310": "1.21.4",
@@ -801,8 +800,8 @@ class TestManylinux(Anylinux):
         """
         policy = request.param
         support_check_map = {
-            "manylinux_2_5": {"37", "38", "39"},
-            "manylinux_2_12": {"37", "38", "39", "310"},
+            "manylinux_2_5": {"38", "39"},
+            "manylinux_2_12": {"38", "39", "310"},
         }
         check_set = support_check_map.get(policy, None)
         if check_set and PYTHON_ABI_MAJ_MIN not in check_set:


### PR DESCRIPTION
With #455 going in, the next release will be a major one, we might as well drop python 3.7 (EOL) at the same time.