### PR TITLE
Demonstrate how ELF extraction/utilities can be done using SQL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ include_package_data = True
 install_requires =
     packaging>=20.9
     pyelftools>=0.24
+    sqlelf>=0.1.0
     importlib_metadata; python_version < "3.8"
 packages = find:
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_package_data = True
 install_requires =
     packaging>=20.9
     pyelftools>=0.24
-    sqlelf>=0.1.0
+    sqlelf>=0.2.0
     importlib_metadata; python_version < "3.8"
 packages = find:
 package_dir =

--- a/src/auditwheel/elfutils.py
+++ b/src/auditwheel/elfutils.py
@@ -12,13 +12,9 @@ from .lddtree import parse_ld_paths
 
 
 def elf_read_dt_needed(fn: str) -> list[str]:
-    sql_engine = sql.make_sql_engine(
-        [fn],
-        recursive=False,
-        flags=elf.GeneratorFlag.DYNAMIC_ENTRIES | elf.GeneratorFlag.STRINGS,
-    )
-    results = sql_engine.execute(
-        """
+    sql_engine = sql.make_sql_engine([fn], recursive=False,
+                                     cache_flags=elf.CacheFlag.DYNAMIC_ENTRIES | elf.CacheFlag.STRINGS)
+    results = sql_engine.execute("""
                         SELECT elf_strings.value
                         FROM elf_dynamic_entries
                         INNER JOIN elf_strings

--- a/src/auditwheel/elfutils.py
+++ b/src/auditwheel/elfutils.py
@@ -42,21 +42,6 @@ def elf_file_filter(paths: Iterator[str]) -> Iterator[tuple[str, ELFFile]]:
                 # not an elf file
                 continue
 
-
-def elf_find_versioned_symbols(elf: ELFFile) -> Iterator[tuple[str, str]]:
-    section = elf.get_section_by_name(".gnu.version_r")
-
-    if section is not None:
-        for verneed, verneed_iter in section.iter_versions():
-            if verneed.name.startswith("ld-linux") or verneed.name in [
-                "ld64.so.2",
-                "ld64.so.1",
-            ]:
-                continue
-            for vernaux in verneed_iter:
-                yield (verneed.name, vernaux.name)
-
-
 def elf_find_ucs2_symbols(elf: ELFFile) -> Iterator[str]:
     section = elf.get_section_by_name(".dynsym")
     if section is not None:

--- a/src/auditwheel/elfutils.py
+++ b/src/auditwheel/elfutils.py
@@ -20,9 +20,8 @@ def elf_read_dt_needed(fn: str) -> list[str]:
                         INNER JOIN elf_strings
                               ON elf_dynamic_entries.value = elf_strings.offset
                         WHERE elf_dynamic_entries.tag = 'NEEDED'
-                       """
-    )
-    return list(results)
+                       """)
+    return [row["value"] for row in list(results)]
 
 
 def elf_file_filter(paths: Iterator[str]) -> Iterator[tuple[str, ELFFile]]:

--- a/src/auditwheel/elfutils.py
+++ b/src/auditwheel/elfutils.py
@@ -12,15 +12,20 @@ from .lddtree import parse_ld_paths
 
 
 def elf_read_dt_needed(fn: str) -> list[str]:
-    sql_engine = sql.make_sql_engine([fn], recursive=False,
-                                     cache_flags=elf.CacheFlag.DYNAMIC_ENTRIES | elf.CacheFlag.STRINGS)
-    results = sql_engine.execute("""
+    sql_engine = sql.make_sql_engine(
+        [fn],
+        recursive=False,
+        cache_flags=elf.CacheFlag.DYNAMIC_ENTRIES | elf.CacheFlag.STRINGS,
+    )
+    results = sql_engine.execute(
+        """
                         SELECT elf_strings.value
                         FROM elf_dynamic_entries
                         INNER JOIN elf_strings
                               ON elf_dynamic_entries.value = elf_strings.offset
                         WHERE elf_dynamic_entries.tag = 'NEEDED'
-                       """)
+                       """
+    )
     return [row["value"] for row in list(results)]
 
 

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -14,7 +14,7 @@ from typing import Iterable
 
 from auditwheel.patcher import ElfPatcher
 
-from .elfutils import elf_read_dt_needed, elf_has_rpaths_or_runpaths, is_subdir
+from .elfutils import elf_has_rpaths_or_runpaths, elf_read_dt_needed, is_subdir
 from .hashfile import hashfile
 from .policy import get_replace_platforms
 from .wheel_abi import get_wheel_elfdata

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -14,7 +14,7 @@ from typing import Iterable
 
 from auditwheel.patcher import ElfPatcher
 
-from .elfutils import elf_read_dt_needed, elf_read_rpaths, is_subdir
+from .elfutils import elf_read_dt_needed, elf_has_rpaths_or_runpaths, is_subdir
 from .hashfile import hashfile
 from .policy import get_replace_platforms
 from .wheel_abi import get_wheel_elfdata
@@ -153,7 +153,7 @@ def copylib(src_path: str, dest_dir: str, patcher: ElfPatcher) -> tuple[str, str
         return new_soname, dest_path
 
     logger.debug("Grafting: %s -> %s", src_path, dest_path)
-    rpaths = elf_read_rpaths(src_path)
+    has_rpaths_or_runpaths = elf_has_rpaths_or_runpaths(src_path)
     shutil.copy2(src_path, dest_path)
     statinfo = os.stat(dest_path)
     if not statinfo.st_mode & stat.S_IWRITE:
@@ -161,7 +161,7 @@ def copylib(src_path: str, dest_dir: str, patcher: ElfPatcher) -> tuple[str, str
 
     patcher.set_soname(dest_path, new_soname)
 
-    if any(itertools.chain(rpaths["rpaths"], rpaths["runpaths"])):
+    if has_rpaths_or_runpaths:
         patcher.set_rpath(dest_path, dest_dir)
 
     return new_soname, dest_path

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -105,7 +105,7 @@ def get_wheel_elfdata(wheel_fn: str):
                     log.debug("key %s, value %s", key, value)
                     versioned_symbols[key].add(value)
 
-                is_py_ext, py_ver = elf_is_python_extension(fn, elf)
+                is_py_ext, py_ver = elf_is_python_extension(fn, sql_engine)
 
                 # If the ELF is a Python extention, we definitely need to
                 # include its external dependencies.

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 import functools
@@ -74,7 +73,6 @@ def get_wheel_elfdata(wheel_fn: str):
 
         platform_wheel = False
         for fn, elf in elf_file_filter(ctx.iter_files()):
-
             sql_engine = sql.make_sql_engine([fn], recursive=False)
 
             platform_wheel = True
@@ -95,10 +93,12 @@ def get_wheel_elfdata(wheel_fn: str):
                 elftree = lddtree(fn)
 
                 # find the versioned symbols by library needed
-                results = sql_engine.execute("""
+                results = sql_engine.execute(
+                    """
                     SELECT file, name
                     FROM elf_version_requirements
-                                   """)
+                                   """
+                )
                 for row in results:
                     key = row["file"]
                     value = row["name"]
@@ -208,11 +208,13 @@ def get_versioned_symbols(libs):
 
     sql_engine = sql.make_sql_engine(libs.keys(), recursive=False)
     # find the versioned symbols by library needed
-    sql_results = sql_engine.execute("""
+    sql_results = sql_engine.execute(
+        """
         SELECT path, file, name
         FROM elf_version_requirements
-                        """)
-    
+                        """
+    )
+
     for row in sql_results:
         path = row["path"]
         key = row["file"]

--- a/tests/unit/test_elfutils.py
+++ b/tests/unit/test_elfutils.py
@@ -8,7 +8,6 @@ from elftools.common.exceptions import ELFError
 from auditwheel.elfutils import (
     elf_file_filter,
     elf_find_ucs2_symbols,
-    elf_find_versioned_symbols,
     elf_read_dt_needed,
     elf_references_PyFPE_jbuf,
 )
@@ -79,54 +78,6 @@ class TestElfFileFilter:
 
         # THEN
         assert len(list(result)) == 0
-
-
-class TestElfFindVersionedSymbols:
-    def test_find_symbols(self):
-        # GIVEN
-        elf = Mock()
-        verneed = Mock()
-        verneed.configure_mock(name="foo-lib")
-        veraux = Mock()
-        veraux.configure_mock(name="foo-lib")
-        elf.get_section_by_name.return_value.iter_versions.return_value = (
-            (verneed, [veraux]),
-        )
-
-        # WHEN
-        symbols = list(elf_find_versioned_symbols(elf))
-
-        # THEN
-        assert symbols == [("foo-lib", "foo-lib")]
-
-    @pytest.mark.parametrize("ld_name", ["ld-linux", "ld64.so.2", "ld64.so.1"])
-    def test_only_ld_linux(self, ld_name):
-        # GIVEN
-        elf = Mock()
-        verneed = Mock()
-        verneed.configure_mock(name=ld_name)
-        veraux = Mock()
-        veraux.configure_mock(name="foo-lib")
-        elf.get_section_by_name.return_value.iter_versions.return_value = (
-            (verneed, [veraux]),
-        )
-
-        # WHEN
-        symbols = list(elf_find_versioned_symbols(elf))
-
-        # THEN
-        assert len(symbols) == 0
-
-    def test_empty_section(self):
-        # GIVEN
-        elf = Mock()
-        elf.get_section_by_name.return_value = None
-
-        # WHEN
-        symbols = list(elf_find_versioned_symbols(elf))
-
-        # THEN
-        assert len(symbols) == 0
 
 
 class TestFindUcs2Symbols:

--- a/tests/unit/test_elfutils.py
+++ b/tests/unit/test_elfutils.py
@@ -28,7 +28,6 @@ class MockSymbol(dict):
 @patch("auditwheel.elfutils.open")
 @patch("auditwheel.elfutils.ELFFile")
 class TestElfReadDt:
-
     def test_needed_libs(self, elffile_mock, open_mock):
         # WHEN
         needed = elf_read_dt_needed("/bin/ls")

--- a/tests/unit/test_elfutils.py
+++ b/tests/unit/test_elfutils.py
@@ -28,34 +28,13 @@ class MockSymbol(dict):
 @patch("auditwheel.elfutils.open")
 @patch("auditwheel.elfutils.ELFFile")
 class TestElfReadDt:
-    def test_missing_section(self, elffile_mock, open_mock):
-        # GIVEN
-        open_mock.return_value.__enter__.return_value = Mock()
-        elffile_mock.return_value.get_section_by_name.return_value = None
-
-        # THEN
-        with pytest.raises(ValueError):
-            # WHEN
-            elf_read_dt_needed("/fake.so")
 
     def test_needed_libs(self, elffile_mock, open_mock):
-        # GIVEN
-        open_mock.return_value.__enter__.return_value = Mock()
-        section_mock = Mock()
-        tag1 = Mock(needed="libz.so")
-        tag1.entry.d_tag = "DT_NEEDED"
-        tag2 = Mock(needed="libfoo.so")
-        tag2.entry.d_tag = "DT_NEEDED"
-        section_mock.iter_tags.return_value = [tag1, tag2]
-        elffile_mock.return_value.get_section_by_name.return_value = section_mock
-
         # WHEN
-        needed = elf_read_dt_needed("/fake.so")
+        needed = elf_read_dt_needed("/bin/ls")
 
         # THEN
-        assert len(needed) == 2
-        assert "libz.so" in needed
-        assert "libfoo.so" in needed
+        assert len(needed) > 0
 
 
 @patch("auditwheel.elfutils.open")


### PR DESCRIPTION
I'm working on [sqlelf](https://github.com/fzakaria/sqlelf) which is a tool that lets you explore ELF files using SQL.

What's really interesting and neat about this tool is that it lets you declaratively write what data you are interested in without knowing the internals of the ELF file format or working with the the necessary ELF parsing library.

The snippets are also very easily runnable outside the codebase which makes validating the tests separately super easy.

Here is a current _draft_ where I have replaced a good number of the functions with their respective SQL equivalent.
I'm interested in feedback or thoughts on the approach.

We can get quite fancy with the SQL to even split the strings of RUNPATH for instance for instance.
![image](https://github.com/pypa/auditwheel/assets/605070/38e792d6-d766-493d-b8c9-2d599638a22a)
