### PR TITLE
Added the option to skip setting library SONAMEs

### DIFF
--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -80,7 +80,7 @@ wheel will abort processing of subsequent wheels.
     )
     p.add_argument(
         "--no-set-soname",
-        "SET_SONAME",
+        dest="SET_SONAME",
         action="store_false",
         help="Move and rename libraries but don't set their SONAME",
         default=True,

--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -79,6 +79,13 @@ wheel will abort processing of subsequent wheels.
         default=True,
     )
     p.add_argument(
+        "--no-set-soname",
+        "SET_SONAME",
+        action="store_false",
+        help="Move and rename libraries but don't set their SONAME",
+        default=True,
+    )
+    p.add_argument(
         "--strip",
         dest="STRIP",
         action="store_true",
@@ -176,6 +183,7 @@ def execute(args, p):
             lib_sdir=args.LIB_SDIR,
             out_dir=args.WHEEL_DIR,
             update_tags=args.UPDATE_TAGS,
+            set_soname=args.SET_SONAME,
             patcher=patcher,
             exclude=args.EXCLUDE,
             strip=args.STRIP,

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -127,7 +127,9 @@ def strip_symbols(libraries: Iterable[str]) -> None:
         check_call(["strip", "-s", lib])
 
 
-def copylib(src_path: str, dest_dir: str, patcher: ElfPatcher, set_soname: bool) -> tuple[str, str]:
+def copylib(
+    src_path: str, dest_dir: str, patcher: ElfPatcher, set_soname: bool
+) -> tuple[str, str]:
     """Graft a shared library from the system into the wheel and update the
     relevant links.
 

--- a/tests/integration/test_bundled_wheels.py
+++ b/tests/integration/test_bundled_wheels.py
@@ -71,6 +71,7 @@ def test_wheel_source_date_epoch(tmp_path, monkeypatch):
         PLAT="manylinux_2_5_x86_64",
         STRIP=False,
         UPDATE_TAGS=True,
+        SET_SONAME=True,
         WHEEL_DIR=str(wheel_output_path),
         WHEEL_FILE=[str(wheel_path)],
         EXCLUDE=[],


### PR DESCRIPTION
I am adding this option locally as I ended up needing it to circumvent this problem I encountered, so I figured I might as well create a PR:
https://stackoverflow.com/questions/77733250/using-patchelf-to-change-the-soname-of-libgldispatch-so-breaks-its-functionality

While not the common flow, it does seem that being able to skip setting the SONAMEs and only relying on file names can have its uses in some cases.