### PR TITLE
fix: `--exclude libfoo.so` shall ignore dependencies of `libfoo.so`

### DIFF
--- a/src/auditwheel/lddtree.py
+++ b/src/auditwheel/lddtree.py
@@ -300,6 +300,7 @@ def lddtree(
     prefix: str = "",
     ldpaths: dict[str, list[str]] | None = None,
     display: str | None = None,
+    exclude: frozenset[str] = frozenset(),
     _first: bool = True,
     _all_libs: dict = {},
 ) -> dict:
@@ -320,6 +321,8 @@ def lddtree(
         will be called.
     display
         The path to show rather than ``path``
+    exclude
+        List of soname (DT_NEEDED) to exclude from the tree
     _first
         Recursive use only; is this the first ELF?
     _all_libs
@@ -402,7 +405,10 @@ def lddtree(
                 elif t.entry.d_tag == "DT_RUNPATH":
                     runpaths = parse_ld_paths(t.runpath, path=path, root=root)
                 elif t.entry.d_tag == "DT_NEEDED":
-                    libs.append(t.needed)
+                    if t.needed in exclude:
+                        log.info(f"Excluding {t.needed}")
+                    else:
+                        libs.append(t.needed)
             if runpaths:
                 # If both RPATH and RUNPATH are set, only the latter is used.
                 rpaths = []
@@ -449,6 +455,7 @@ def lddtree(
                     prefix,
                     ldpaths,
                     display=fullpath,
+                    exclude=exclude,
                     _first=False,
                     _all_libs=_all_libs,
                 )

--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -109,6 +109,7 @@ def execute(args, p):
     from .repair import repair_wheel
     from .wheel_abi import NonPlatformWheel, analyze_wheel_abi
 
+    exclude = frozenset(args.EXCLUDE)
     wheel_policy = WheelPolicies()
 
     for wheel_file in args.WHEEL_FILE:
@@ -121,7 +122,7 @@ def execute(args, p):
             os.makedirs(args.WHEEL_DIR)
 
         try:
-            wheel_abi = analyze_wheel_abi(wheel_policy, wheel_file)
+            wheel_abi = analyze_wheel_abi(wheel_policy, wheel_file, exclude)
         except NonPlatformWheel:
             logger.info(NonPlatformWheel.LOG_MESSAGE)
             return 1
@@ -177,7 +178,7 @@ def execute(args, p):
             out_dir=args.WHEEL_DIR,
             update_tags=args.UPDATE_TAGS,
             patcher=patcher,
-            exclude=args.EXCLUDE,
+            exclude=exclude,
             strip=args.STRIP,
         )
 

--- a/src/auditwheel/main_show.py
+++ b/src/auditwheel/main_show.py
@@ -35,7 +35,7 @@ def execute(args, p):
         p.error("cannot access %s. No such file" % args.WHEEL_FILE)
 
     try:
-        winfo = analyze_wheel_abi(wheel_policy, args.WHEEL_FILE)
+        winfo = analyze_wheel_abi(wheel_policy, args.WHEEL_FILE, frozenset())
     except NonPlatformWheel:
         logger.info(NonPlatformWheel.LOG_MESSAGE)
         return 1

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -39,10 +39,10 @@ def repair_wheel(
     out_dir: str,
     update_tags: bool,
     patcher: ElfPatcher,
-    exclude: list[str],
+    exclude: frozenset[str],
     strip: bool = False,
 ) -> str | None:
-    external_refs_by_fn = get_wheel_elfdata(wheel_policy, wheel_path)[1]
+    external_refs_by_fn = get_wheel_elfdata(wheel_policy, wheel_path, exclude)[1]
 
     # Do not repair a pure wheel, i.e. has no external refs
     if not external_refs_by_fn:
@@ -72,9 +72,7 @@ def repair_wheel(
             ext_libs: dict[str, str] = v[abis[0]]["libs"]
             replacements: list[tuple[str, str]] = []
             for soname, src_path in ext_libs.items():
-                if soname in exclude:
-                    logger.info(f"Excluding {soname}")
-                    continue
+                assert soname not in exclude
 
                 if src_path is None:
                     raise ValueError(

--- a/tests/integration/test_bundled_wheels.py
+++ b/tests/integration/test_bundled_wheels.py
@@ -29,14 +29,16 @@ HERE = Path(__file__).parent.resolve()
 )
 def test_analyze_wheel_abi(file, external_libs):
     wheel_policies = WheelPolicies(libc=Libc.GLIBC, arch="x86_64")
-    winfo = analyze_wheel_abi(wheel_policies, str(HERE / file))
+    winfo = analyze_wheel_abi(wheel_policies, str(HERE / file), frozenset())
     assert set(winfo.external_refs["manylinux_2_5_x86_64"]["libs"]) == external_libs
 
 
 def test_analyze_wheel_abi_pyfpe():
     wheel_policies = WheelPolicies(libc=Libc.GLIBC, arch="x86_64")
     winfo = analyze_wheel_abi(
-        wheel_policies, str(HERE / "fpewheel-0.0.0-cp35-cp35m-linux_x86_64.whl")
+        wheel_policies,
+        str(HERE / "fpewheel-0.0.0-cp35-cp35m-linux_x86_64.whl"),
+        frozenset(),
     )
     assert (
         winfo.sym_tag == "manylinux_2_5_x86_64"

--- a/tests/integration/test_bundled_wheels.py
+++ b/tests/integration/test_bundled_wheels.py
@@ -21,15 +21,20 @@ HERE = Path(__file__).parent.resolve()
 
 
 @pytest.mark.parametrize(
-    "file, external_libs",
+    "file, external_libs, exclude",
     [
-        ("cffi-1.5.0-cp27-none-linux_x86_64.whl", {"libffi.so.5"}),
-        ("python_snappy-0.5.2-pp260-pypy_41-linux_x86_64.whl", {"libsnappy.so.1"}),
+        ("cffi-1.5.0-cp27-none-linux_x86_64.whl", {"libffi.so.5"}, frozenset()),
+        ("cffi-1.5.0-cp27-none-linux_x86_64.whl", set(), frozenset(["libffi.so.5"])),
+        (
+            "python_snappy-0.5.2-pp260-pypy_41-linux_x86_64.whl",
+            {"libsnappy.so.1"},
+            frozenset(),
+        ),
     ],
 )
-def test_analyze_wheel_abi(file, external_libs):
+def test_analyze_wheel_abi(file, external_libs, exclude):
     wheel_policies = WheelPolicies(libc=Libc.GLIBC, arch="x86_64")
-    winfo = analyze_wheel_abi(wheel_policies, str(HERE / file), frozenset())
+    winfo = analyze_wheel_abi(wheel_policies, str(HERE / file), exclude)
     assert set(winfo.external_refs["manylinux_2_5_x86_64"]["libs"]) == external_libs
 
 

--- a/tests/unit/test_wheel_abi.py
+++ b/tests/unit/test_wheel_abi.py
@@ -48,6 +48,6 @@ class TestGetWheelElfdata:
         wheel_policy = WheelPolicies()
 
         with pytest.raises(RuntimeError) as exec_info:
-            wheel_abi.get_wheel_elfdata(wheel_policy, "/fakepath")
+            wheel_abi.get_wheel_elfdata(wheel_policy, "/fakepath", frozenset())
 
         assert exec_info.value.args == (message,)


### PR DESCRIPTION
When using `--exclude libfoo.so`, dependencies of `libfoo.so` are still being analyzed & grafted.
This commit moves the exclusion analysis to `lddtree` and filters  `libfoo.so` `DT_NEEDED` entries thus excluding its dependencies from the tree.