### PR TITLE
Set RPATH on copied libs to the folder where they're copied ($ORIGIN)

### DIFF
--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -161,7 +161,7 @@ def copylib(src_path: str, dest_dir: str, patcher: ElfPatcher) -> tuple[str, str
     patcher.set_soname(dest_path, new_soname)
 
     if any(itertools.chain(rpaths["rpaths"], rpaths["runpaths"])):
-        patcher.set_rpath(dest_path, dest_dir)
+        patcher.set_rpath(dest_path, "$ORIGIN")
 
     return new_soname, dest_path
 


### PR DESCRIPTION
I believe this would address #451.

We use a tool that uses `ldd` to make sure software packages don't have outside dependencies. After starting to try using auditwheel, `.so` files under the libs folder are flagged because the RPATH is set to `dest_dir`, which is not right. Even though it should never have runtime implications (because the RPATH of the first library in the dependency chain is correct), we'd rather fix this upstream rather than having to add explicit allowlisting to our setup.

This fixes that by setting RPATH to `$ORIGIN` in those cases. I've done some manual testing and that seems to help `ldd` find the dependencies properly. That looks like the right thing, but I may very well be missing something.

I'm happy to add tests if required (pointers regarding to where to look at would be appreciated in that case).