### PR TITLE
fix: replace RPATH on copied libs to the folder where they're copied ($ORIGIN)

### DIFF
--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -161,7 +161,7 @@ def copylib(src_path: str, dest_dir: str, patcher: ElfPatcher) -> tuple[str, str
     patcher.set_soname(dest_path, new_soname)
 
     if any(itertools.chain(rpaths["rpaths"], rpaths["runpaths"])):
-        patcher.set_rpath(dest_path, dest_dir)
+        patcher.set_rpath(dest_path, "$ORIGIN")
 
     return new_soname, dest_path
 

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -498,29 +498,31 @@ class Anylinux:
         )
         assert output.strip() == "11"
         with zipfile.ZipFile(os.path.join(io_folder, repaired_wheel)) as w:
-            for name in w.namelist():
-                if "testrpath/.libs/lib" in name:
-                    with w.open(name) as f:
-                        elf = ELFFile(io.BytesIO(f.read()))
-                        dynamic = elf.get_section_by_name(".dynamic")
-                        assert (
-                            len(
-                                [
-                                    t
-                                    for t in dynamic.iter_tags()
-                                    if t.entry.d_tag == "DT_RUNPATH"
-                                ]
-                            )
-                            == 0
-                        )
-                        if ".libs/liba" in name:
-                            rpath_tags = [
+            libraries = tuple(name for name in w.namelist() if "testrpath.libs/lib" in name)
+            assert len(libraries) == 2
+            assert any(".libs/liba" in name for name in libraries)
+            for name in libraries:
+                with w.open(name) as f:
+                    elf = ELFFile(io.BytesIO(f.read()))
+                    dynamic = elf.get_section_by_name(".dynamic")
+                    assert (
+                        len(
+                            [
                                 t
                                 for t in dynamic.iter_tags()
-                                if t.entry.d_tag == "DT_RPATH"
+                                if t.entry.d_tag == "DT_RUNPATH"
                             ]
-                            assert len(rpath_tags) == 1
-                            assert rpath_tags[0].rpath == "$ORIGIN/."
+                        )
+                        == 0
+                    )
+                    if ".libs/liba" in name:
+                        rpath_tags = [
+                            t
+                            for t in dynamic.iter_tags()
+                            if t.entry.d_tag == "DT_RPATH"
+                        ]
+                        assert len(rpath_tags) == 1
+                        assert rpath_tags[0].rpath == "$ORIGIN"
 
     def test_build_repair_multiple_top_level_modules_wheel(
         self, any_manylinux_container, docker_python, io_folder

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -498,7 +498,9 @@ class Anylinux:
         )
         assert output.strip() == "11"
         with zipfile.ZipFile(os.path.join(io_folder, repaired_wheel)) as w:
-            libraries = tuple(name for name in w.namelist() if "testrpath.libs/lib" in name)
+            libraries = tuple(
+                name for name in w.namelist() if "testrpath.libs/lib" in name
+            )
             assert len(libraries) == 2
             assert any(".libs/liba" in name for name in libraries)
             for name in libraries:


### PR DESCRIPTION
As the diff in tests showed, this was the original intent but the tests were not working properly.

close #477  (maintainers can't push to that PR)

> I believe this would address https://github.com/pypa/auditwheel/issues/451.
>
> We use a tool that uses ldd to make sure software packages don't have outside dependencies. After starting to try using auditwheel, .so files under the libs folder are flagged because the RPATH is set to dest_dir, which is not right. Even though it should never have runtime implications (because the RPATH of the first library in the dependency chain is correct), we'd rather fix this upstream rather than having to add explicit allowlisting to our setup.
>
> This fixes that by setting RPATH to $ORIGIN in those cases. I've done some manual testing and that seems to help ldd find the dependencies properly. That looks like the right thing, but I may very well be missing something.
>
> I'm happy to add tests if required (pointers regarding to where to look at would be appreciated in that case).