### PR TITLE
Portability fixes when running on windows

### DIFF
--- a/src/auditwheel/elfutils.py
+++ b/src/auditwheel/elfutils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import os
-from os.path import basename, realpath, relpath
+from os.path import basename
+from pathlib import Path
 from typing import Iterator
 
 from elftools.common.exceptions import ELFError
@@ -126,17 +126,14 @@ def elf_read_rpaths(fn: str) -> dict[str, list[str]]:
     return result
 
 
-def is_subdir(path: str, directory: str) -> bool:
+def is_subdir(path: str | Path | None, directory: str | Path) -> bool:
     if path is None:
         return False
 
-    path = realpath(path)
-    directory = realpath(directory)
+    path = Path(path).resolve()
+    directory = Path(directory).resolve()
 
-    relative = relpath(path, directory)
-    if relative.startswith(os.pardir):
-        return False
-    return True
+    return directory in path.parents
 
 
 def get_undefined_symbols(path: str) -> set[str]:

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -9,6 +9,7 @@ import shutil
 import stat
 from os.path import abspath, basename, dirname, exists, isabs
 from os.path import join as pjoin
+from pathlib import Path
 from subprocess import check_call
 from typing import Iterable
 
@@ -237,7 +238,7 @@ def _resolve_rpath_tokens(rpath: str, lib_base_dir: str) -> str:
 
 def _path_is_script(path: str) -> bool:
     # Looks something like "uWSGI-2.0.21.data/scripts/uwsgi"
-    components = path.split("/")
+    components = Path(path).parts
     return (
         len(components) == 3
         and components[0].endswith(".data")
@@ -265,7 +266,7 @@ def _replace_elf_script_with_shim(package_name: str, orig_path: str) -> str:
     new_path = os.path.join(scripts_dir, os.path.basename(orig_path))
     os.rename(orig_path, new_path)
 
-    with open(orig_path, "w") as f:
+    with open(orig_path, "w", newline="\n") as f:
         f.write(_script_shim(new_path))
     os.chmod(orig_path, os.stat(new_path).st_mode)
 
@@ -286,5 +287,5 @@ if __name__ == "__main__":
         sys.argv,
     )
 """.format(
-        binary_path=binary_path,
+        binary_path=Path(binary_path).as_posix(),
     )


### PR DESCRIPTION
As part of [repairwheel](https://github.com/jvolkman/repairwheel), auditwheel is vendored and can patch linux wheels from Windows. These are some of the more innocuous tweaks I've had to make to run successfully in a Windows environment.

Fixes:
- path handling in various places ('\\' vs '/')
- newline when writing the new binary "script" shim
