### PR TITLE
fix: don't create empty .libs directory

### DIFF
--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -64,9 +64,6 @@ def repair_wheel(
 
         dest_dir = match.group("name") + lib_sdir
 
-        if not exists(dest_dir):
-            os.mkdir(dest_dir)
-
         # here, fn is a path to an ELF file (lib or executable) in
         # the wheel, and v['libs'] contains its required libs
         for fn, v in external_refs_by_fn.items():
@@ -84,6 +81,8 @@ def repair_wheel(
                         % soname
                     )
 
+                if not exists(dest_dir):
+                    os.mkdir(dest_dir)
                 new_soname, new_path = copylib(src_path, dest_dir, patcher)
                 soname_map[soname] = (new_soname, new_path)
                 replacements.append((soname, new_soname))

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -1004,7 +1004,9 @@ class TestManylinux(Anylinux):
 
         with zipfile.ZipFile(os.path.join(io_folder, repaired_wheel)) as z:
             for file in z.namelist():
-                assert not file.startswith("testsimple.libs"), "should not have empty .libs folder"
+                assert not file.startswith(
+                    "testsimple.libs"
+                ), "should not have empty .libs folder"
 
         docker_exec(docker_python, f"pip install /io/{repaired_wheel}")
         docker_exec(

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -1004,8 +1004,7 @@ class TestManylinux(Anylinux):
 
         with zipfile.ZipFile(os.path.join(io_folder, repaired_wheel)) as z:
             for file in z.namelist():
-                if file.startswith("testsimple.libs"):
-                    raise Exception("should not have empty .libs folder")
+                assert not file.startswith("testsimple.libs"), "should not have empty .libs folder"
 
         docker_exec(docker_python, f"pip install /io/{repaired_wheel}")
         docker_exec(

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -20,7 +20,6 @@ from auditwheel.policy import WheelPolicies, get_arch_name
 
 logger = logging.getLogger(__name__)
 
-
 ENCODING = "utf-8"
 PLATFORM = get_arch_name()
 MANYLINUX1_IMAGE_ID = f"quay.io/pypa/manylinux1_{PLATFORM}:latest"
@@ -1000,7 +999,13 @@ class TestManylinux(Anylinux):
             repaired_tag = f"{expect_tag}.{target_tag}"
         repaired_wheel = f"testsimple-0.0.1-{PYTHON_ABI}-{repaired_tag}.whl"
         assert repaired_wheel in filenames
+
         assert_show_output(manylinux_ctr, repaired_wheel, expect, True)
+
+        with zipfile.ZipFile(os.path.join(io_folder, repaired_wheel)) as z:
+            for file in z.namelist():
+                if file.startswith("testsimple.libs"):
+                    raise Exception("should not have empty .libs folder")
 
         docker_exec(docker_python, f"pip install /io/{repaired_wheel}")
         docker_exec(


### PR DESCRIPTION
close https://github.com/pypa/auditwheel/issues/488

only create `${package}.libs` when needed