### PR TITLE
Add option to add an extra lib name tag to wheel's short hash

### DIFF
--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 from os.path import abspath, basename, exists, isfile
 
 from auditwheel.patcher import Patchelf
@@ -100,6 +101,12 @@ wheel will abort processing of subsequent wheels.
         help="Do not check for higher policy compatibility",
         default=False,
     )
+    p.add_argument(
+        "--extra-lib-name-tag",
+        dest="EXTRA_LIB_NAME_TAG",
+        help="Extra, optional tag for copied library names",
+        default=os.environ.get("AUDITWHEEL_EXTRA_LIB_NAME_TAG", None),
+    )
     p.set_defaults(func=execute)
 
 
@@ -180,6 +187,7 @@ def execute(args, p):
             patcher=patcher,
             exclude=exclude,
             strip=args.STRIP,
+            extra_lib_name_tag=args.EXTRA_LIB_NAME_TAG,
         )
 
         if out_wheel is not None:

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -11,7 +11,7 @@ from os.path import abspath, basename, dirname, exists, isabs
 from os.path import join as pjoin
 from pathlib import Path
 from subprocess import check_call
-from typing import Iterable, Optional
+from typing import Iterable
 
 from auditwheel.patcher import ElfPatcher
 

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -11,7 +11,7 @@ from os.path import abspath, basename, dirname, exists, isabs
 from os.path import join as pjoin
 from pathlib import Path
 from subprocess import check_call
-from typing import Iterable
+from typing import Iterable, Optional
 
 from auditwheel.patcher import ElfPatcher
 
@@ -42,7 +42,7 @@ def repair_wheel(
     patcher: ElfPatcher,
     exclude: frozenset[str],
     strip: bool = False,
-    extra_lib_name_tag: str = None,
+    extra_lib_name_tag: Optional[str] = None,
 ) -> str | None:
     external_refs_by_fn = get_wheel_elfdata(wheel_policy, wheel_path, exclude)[1]
 
@@ -131,7 +131,7 @@ def strip_symbols(libraries: Iterable[str]) -> None:
 
 
 def copylib(
-    src_path: str, dest_dir: str, patcher: ElfPatcher, extra_lib_name_tag: str = None
+    src_path: str, dest_dir: str, patcher: ElfPatcher, extra_lib_name_tag: Optional[str] = None
 ) -> tuple[str, str]:
     """Graft a shared library from the system into the wheel and update the
     relevant links.

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -42,6 +42,7 @@ def repair_wheel(
     patcher: ElfPatcher,
     exclude: frozenset[str],
     strip: bool = False,
+    extra_lib_name_tag: str = None,
 ) -> str | None:
     external_refs_by_fn = get_wheel_elfdata(wheel_policy, wheel_path, exclude)[1]
 
@@ -83,7 +84,9 @@ def repair_wheel(
 
                 if not exists(dest_dir):
                     os.mkdir(dest_dir)
-                new_soname, new_path = copylib(src_path, dest_dir, patcher)
+                new_soname, new_path = copylib(
+                    src_path, dest_dir, patcher, extra_lib_name_tag=extra_lib_name_tag
+                )
                 soname_map[soname] = (new_soname, new_path)
                 replacements.append((soname, new_soname))
             if replacements:
@@ -127,7 +130,9 @@ def strip_symbols(libraries: Iterable[str]) -> None:
         check_call(["strip", "-s", lib])
 
 
-def copylib(src_path: str, dest_dir: str, patcher: ElfPatcher) -> tuple[str, str]:
+def copylib(
+    src_path: str, dest_dir: str, patcher: ElfPatcher, extra_lib_name_tag: str = None
+) -> tuple[str, str]:
     """Graft a shared library from the system into the wheel and update the
     relevant links.
 
@@ -142,6 +147,9 @@ def copylib(src_path: str, dest_dir: str, patcher: ElfPatcher) -> tuple[str, str
 
     with open(src_path, "rb") as f:
         shorthash = hashfile(f)[:8]
+
+    if extra_lib_name_tag:
+        shorthash = f"{extra_lib_name_tag}-{shorthash}"
 
     src_name = os.path.basename(src_path)
     base, ext = src_name.split(".", 1)

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -42,7 +42,7 @@ def repair_wheel(
     patcher: ElfPatcher,
     exclude: frozenset[str],
     strip: bool = False,
-    extra_lib_name_tag: Optional[str] = None,
+    extra_lib_name_tag: str | None = None,
 ) -> str | None:
     external_refs_by_fn = get_wheel_elfdata(wheel_policy, wheel_path, exclude)[1]
 
@@ -131,7 +131,10 @@ def strip_symbols(libraries: Iterable[str]) -> None:
 
 
 def copylib(
-    src_path: str, dest_dir: str, patcher: ElfPatcher, extra_lib_name_tag: Optional[str] = None
+    src_path: str,
+    dest_dir: str,
+    patcher: ElfPatcher,
+    extra_lib_name_tag: str | None = None,
 ) -> tuple[str, str]:
     """Graft a shared library from the system into the wheel and update the
     relevant links.


### PR DESCRIPTION
I've been using this on wheels for my Fiona and Rasterio projects, which may be used together and which have a score of potentially overlapping dependencies. If it's not deemed useful to auditwheel, I understand.