### PR TITLE
Make order of files in repaired wheel deterministic

### DIFF
--- a/src/auditwheel/tools.py
+++ b/src/auditwheel/tools.py
@@ -77,6 +77,11 @@ def dir2zip(in_dir: str, zip_fname: str, date_time: datetime | None = None) -> N
         for root, dirs, files in os.walk(in_dir):
             dirs.sort()
             files.sort()
+            if root == in_dir:
+                # Place the contents of *.dist-info at the end of
+                # the archive, as recommended by PEP 427.
+                dirs.sort(key=lambda p: p.endswith(".dist-info"))
+
             for dir in dirs:
                 dname = os.path.join(root, dir)
                 out_dname = os.path.relpath(dname, in_dir) + "/"

--- a/src/auditwheel/tools.py
+++ b/src/auditwheel/tools.py
@@ -75,6 +75,8 @@ def dir2zip(in_dir: str, zip_fname: str, date_time: datetime | None = None) -> N
     compression = zipfile.ZIP_DEFLATED
     with zipfile.ZipFile(zip_fname, "w", compression=compression) as z:
         for root, dirs, files in os.walk(in_dir):
+            dirs.sort()
+            files.sort()
             for dir in dirs:
                 dname = os.path.join(root, dir)
                 out_dname = os.path.relpath(dname, in_dir) + "/"

--- a/src/auditwheel/wheeltools.py
+++ b/src/auditwheel/wheeltools.py
@@ -71,6 +71,8 @@ def rewrite_record(bdist_dir: str) -> None:
 
     def walk() -> Generator[str, None, None]:
         for dir, dirs, files in os.walk(bdist_dir):
+            dirs.sort()
+            files.sort()
             for f in files:
                 yield pjoin(dir, f)
 


### PR DESCRIPTION
Currently, when running `auditwheel repair`, the contents of the output whl file are unpredictable:
- The order of entries in the zip archive is unpredictable.
- The order of lines in the "RECORD" file is unpredictable.
In both cases, the order is dependent on the order of entries returned by `os.walk`.

This is a problem for build reproducibility - provided that the build process is sufficiently well defined, different people should be able to run the same process on different machines and get identical outputs.

Note that when `setuptools` or `wheel` generates a whl file, it does something similar (see `WheelFile.write_files` in `wheel.wheelfile`.)  The code here won't do quite the same as what setuptools does, but that shouldn't be a problem.
