### PR TITLE
Support comma separated list values in --exclude argument

### DIFF
--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -107,7 +107,7 @@ wheel will abort processing of subsequent wheels.
         help="Exclude SONAME from grafting into the resulting wheel "
         "Please make sure wheel metadata reflects your dependencies. "
         "See https://github.com/pypa/auditwheel/pull/411#issuecomment-1500826281 "
-        "(can be specified multiple times) "
+        "(can be specified multiple times, or as a comma-separated list) "
         "(can contain wildcards, for example libfoo.so.*)",
         action="append",
         default=[],
@@ -140,7 +140,9 @@ def execute(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
     from auditwheel.repair import repair_wheel
     from auditwheel.wheel_abi import analyze_wheel_abi
 
-    exclude: frozenset[str] = frozenset(args.EXCLUDE)
+    exclude: frozenset[str] = frozenset(
+        item.strip() for group in args.EXCLUDE for item in group.split(",")
+    )
     wheel_dir: Path = args.WHEEL_DIR.absolute()
     wheel_files: list[Path] = args.WHEEL_FILE
 

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -710,14 +710,22 @@ class Anylinux:
 
         assert len(sbom_dependencies) == len(component_purls) + 1
 
-    def test_exclude(self, anylinux: AnyLinuxContainer) -> None:
+    @pytest.mark.parametrize(
+        "excludes",
+        [
+            pytest.param(["liba.so"], id="single-flag"),
+            pytest.param(["liba.so", "libb.so"], id="multiple-flags"),
+            pytest.param(["liba.so,libb.so"], id="comma-separated"),
+        ],
+    )
+    def test_exclude(self, anylinux: AnyLinuxContainer, excludes: list[str]) -> None:
         """Test the --exclude argument to avoid grafting certain libraries."""
         test_path = "/auditwheel_src/tests/integration/testrpath"
         orig_wheel = anylinux.build_wheel(test_path)
 
         output = anylinux.repair(
             orig_wheel,
-            excludes=["liba.so"],
+            excludes=excludes,
             library_paths=[f"{test_path}/a"],
         )
         assert "Excluding liba.so" in output


### PR DESCRIPTION
Previously we had to add a separate --exclude flag for each lib:

`auditwheel repair test.whl --exclude=liba.so --exclude=libx.so`

This PR allows passing in multiple libs as a comma separated list:

`auditwheel repair test.whl --exclude=liba.so,libx.so`

