### PR TITLE
ci: run aarch64 tests on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,18 +37,14 @@ jobs:
         run: pipx run nox -s test-dist -- 3.9
 
   test:
-    name: CPython ${{ matrix.python }}
+    name: CPython ${{ matrix.python }} on ${{ matrix.runner }}
     needs: test-dist
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - python: "3.9"
-          - python: "3.10"
-          - python: "3.11"
-          - python: "3.12"
-          - python: "3.13"
+        runner: [ ubuntu-24.04, ubuntu-24.04-arm ]
+        python: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,7 +58,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python }}"
-          architecture: x64
           allow-prereleases: true
       - name: Run tests
         run: pipx run nox -s tests-${{ matrix.python }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ branches:
 
 jobs:
   include:
-  - arch: arm64
   - arch: ppc64le
   - arch: s390x
   allow_failures:
@@ -34,14 +33,14 @@ install:
   - gpgv ${HOME}/codecov.SHA256SUM.sig ${HOME}/codecov.SHA256SUM
   - pushd ${HOME} && shasum -a 256 -c codecov.SHA256SUM && popd
   - chmod +x ${HOME}/codecov
-  - if [ "$(uname -m)" != "aarch64" ]; then qemu-x86_64-static ${HOME}/codecov --version; fi
+  - qemu-x86_64-static ${HOME}/codecov --version
   - pip install nox
 
 script:
   - nox -s tests-3.12
 
 after_success:
-  - if [ "$(uname -m)" != "aarch64" ]; then qemu-x86_64-static ${HOME}/codecov; fi
+  - qemu-x86_64-static ${HOME}/codecov
 
 cache:
   directories:


### PR DESCRIPTION
Speed-up & extend testing by moving aarch64 from Travis CI to GitHub Actions.