### PR TITLE
chore: refactor test_manylinux

### DIFF
--- a/tests/integration/internal_rpath/setup.py
+++ b/tests/integration/internal_rpath/setup.py
@@ -5,7 +5,7 @@ from setuptools import Extension, find_packages, setup
 package_name = "internal_rpath"
 setup(
     name=package_name,
-    version="1.0",
+    version="0.0.1",
     description="Auditwheel multiple top-level extensions example",
     package_data={package_name: ["liba.so"]},
     packages=find_packages(),

--- a/tests/integration/multiple_top_level/setup.py
+++ b/tests/integration/multiple_top_level/setup.py
@@ -4,7 +4,7 @@ from setuptools import Extension, find_packages, setup
 
 setup(
     name="multiple_top_level",
-    version="1.0",
+    version="0.0.1",
     description="Auditwheel multiple top-level extensions example",
     packages=find_packages(where="src"),
     ext_modules=[

--- a/tests/integration/nonpy_rpath/setup.py
+++ b/tests/integration/nonpy_rpath/setup.py
@@ -94,7 +94,7 @@ crypt_example = Library(
 
 setup(
     name="nonpy_rpath",
-    version="0.1.0",
+    version="0.0.1",
     packages=find_packages(),
     description="Test package for nonpy_rpath",
     ext_modules=[crypt_example, nonpy_rpath_module],


### PR DESCRIPTION
This should ease a bit writing new integration tests.
The logic to build command lines has been moved in helpers so that tests are not clobbered with multiple lines just for that but instead focus on what's being tested.