### PR TITLE
feat: add option to set zip compression level

### DIFF
--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -44,11 +44,11 @@ wheel will abort processing of subsequent wheels.
     parser.add_argument("WHEEL_FILE", type=Path, help="Path to wheel file.", nargs="+")
     parser.add_argument(
         "-z",
-        "--zip-level",
+        "--zip-compression-level",
         action=EnvironmentDefault,
-        metavar="zip",
-        env="AUDITWHEEL_ZIP_LEVEL",
-        dest="zip",
+        metavar="ZIP_COMPRESSION_LEVEL",
+        env="AUDITWHEEL_ZIP_COMPRESSION_LEVEL",
+        dest="ZIP_COMPRESSION_LEVEL",
         type=int,
         help="Compress level to be used to create zip file.",
         choices=list(range(zlib.Z_NO_COMPRESSION, zlib.Z_BEST_COMPRESSION + 1)),
@@ -133,7 +133,7 @@ def execute(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
     wheel_dir: Path = args.WHEEL_DIR.absolute()
     wheel_files: list[Path] = args.WHEEL_FILE
     wheel_policy = WheelPolicies()
-    tools._COMPRESS_LEVEL = args.zip
+    tools._ZIP_COMPRESSION_LEVEL = args.ZIP_COMPRESSION_LEVEL
 
     for wheel_file in wheel_files:
         if not wheel_file.is_file():

--- a/src/auditwheel/main_repair.py
+++ b/src/auditwheel/main_repair.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from auditwheel.patcher import Patchelf
 
-from . import tools
 from .policy import WheelPolicies
 from .tools import EnvironmentDefault
 
@@ -133,7 +132,6 @@ def execute(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
     wheel_dir: Path = args.WHEEL_DIR.absolute()
     wheel_files: list[Path] = args.WHEEL_FILE
     wheel_policy = WheelPolicies()
-    tools._ZIP_COMPRESSION_LEVEL = args.ZIP_COMPRESSION_LEVEL
 
     for wheel_file in wheel_files:
         if not wheel_file.is_file():
@@ -212,6 +210,7 @@ def execute(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
             patcher=patcher,
             exclude=exclude,
             strip=args.STRIP,
+            zip_compression_level=args.ZIP_COMPRESSION_LEVEL,
         )
 
         if out_wheel is not None:

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -41,7 +41,8 @@ def repair_wheel(
     update_tags: bool,
     patcher: ElfPatcher,
     exclude: frozenset[str],
-    strip: bool = False,
+    strip: bool,
+    zip_compression_level: int,
 ) -> Path | None:
     elf_data = get_wheel_elfdata(wheel_policy, wheel_path, exclude)
     external_refs_by_fn = elf_data.full_external_refs
@@ -57,6 +58,7 @@ def repair_wheel(
 
     with InWheelCtx(wheel_path) as ctx:
         ctx.out_wheel = out_dir / wheel_fname
+        ctx.zip_compression_level = zip_compression_level
 
         match = WHEEL_INFO_RE(wheel_fname)
         if not match:

--- a/src/auditwheel/tools.py
+++ b/src/auditwheel/tools.py
@@ -183,7 +183,20 @@ class EnvironmentDefault(argparse.Action):
         self.env = env
         if self.env_default:
             if type:
-                self.env_default = type(self.env_default)
+                try:
+                    self.env_default = type(self.env_default)
+                except Exception:
+                    self.option_strings = kwargs["option_strings"]
+                    args = {
+                        "value": self.env_default,
+                        "type": type,
+                        "env": self.env,
+                    }
+                    msg = (
+                        "invalid type: %(value)r from environment variable "
+                        "%(env)r cannot be converted to %(type)r"
+                    )
+                    raise argparse.ArgumentError(self, msg % args) from None
             default = self.env_default
         if default:
             required = False

--- a/src/auditwheel/tools.py
+++ b/src/auditwheel/tools.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 # Override via AUDITWHEEL_ZIP_LEVEL/--zip-level for:
 # - some test builds that needs no compression at all (0)
 # - bandwidth-constrained or large amount of downloads (9)
-_COMPRESS_LEVEL = zlib.Z_DEFAULT_COMPRESSION
+_ZIP_COMPRESSION_LEVEL = zlib.Z_DEFAULT_COMPRESSION
 
 
 def unique_by_index(sequence: Iterable[_T]) -> list[_T]:
@@ -156,7 +156,7 @@ def dir2zip(in_dir: Path, zip_fname: Path, date_time: datetime | None = None) ->
                 zinfo.date_time = date_time_args
                 zinfo.compress_type = compression
                 with open(fname, "rb") as fp:
-                    z.writestr(zinfo, fp.read(), compresslevel=_COMPRESS_LEVEL)
+                    z.writestr(zinfo, fp.read(), compresslevel=_ZIP_COMPRESSION_LEVEL)
     logger.debug(
         "dir2zip from %s to %s takes %s", in_dir, zip_fname, datetime.now() - start
     )

--- a/src/auditwheel/tools.py
+++ b/src/auditwheel/tools.py
@@ -198,9 +198,11 @@ class EnvironmentDefault(argparse.Action):
                     )
                     raise argparse.ArgumentError(self, msg % args) from None
             default = self.env_default
-        if default:
-            required = False
-        if self.env_default and choices is not None and self.env_default not in choices:
+        if (
+            self.env_default is not None
+            and choices is not None
+            and self.env_default not in choices
+        ):
             self.option_strings = kwargs["option_strings"]
             args = {
                 "value": self.env_default,
@@ -213,7 +215,12 @@ class EnvironmentDefault(argparse.Action):
             )
             raise argparse.ArgumentError(self, msg % args)
 
-        super().__init__(default=default, required=required, choices=choices, **kwargs)
+        if default is not None:
+            required = False
+
+        super().__init__(
+            default=default, required=required, choices=choices, type=type, **kwargs
+        )
 
     def __call__(
         self,

--- a/src/auditwheel/tools.py
+++ b/src/auditwheel/tools.py
@@ -1,15 +1,26 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import os
 import subprocess
 import zipfile
+import zlib
 from collections.abc import Generator, Iterable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypeVar
 
 _T = TypeVar("_T")
+
+logger = logging.getLogger(__name__)
+
+# Default: zlib.Z_DEFAULT_COMPRESSION (-1 aka. level 6) balances speed and size.
+# Maintained for typical builds where iteration speed outweighs distribution savings.
+# Override via AUDITWHEEL_ZIP_LEVEL/--zip-level for:
+# - some test builds that needs no compression at all (0)
+# - bandwidth-constrained or large amount of downloads (9)
+_COMPRESS_LEVEL = zlib.Z_DEFAULT_COMPRESSION
 
 
 def unique_by_index(sequence: Iterable[_T]) -> list[_T]:
@@ -90,6 +101,7 @@ def zip2dir(zip_fname: Path, out_dir: Path) -> None:
     out_dir : str
         Directory path containing files to go in the zip archive
     """
+    start = datetime.now()
     with zipfile.ZipFile(zip_fname, "r") as z:
         for name in z.namelist():
             member = z.getinfo(name)
@@ -102,6 +114,9 @@ def zip2dir(zip_fname: Path, out_dir: Path) -> None:
                 attr &= 511  # only keep permission bits
                 attr |= 6 << 6  # at least read/write for current user
                 os.chmod(extracted_path, attr)
+    logger.debug(
+        "zip2dir from %s to %s takes %s", zip_fname, out_dir, datetime.now() - start
+    )
 
 
 def dir2zip(in_dir: Path, zip_fname: Path, date_time: datetime | None = None) -> None:
@@ -120,6 +135,7 @@ def dir2zip(in_dir: Path, zip_fname: Path, date_time: datetime | None = None) ->
     date_time : Optional[datetime]
         Time stamp to set on each file in the archive
     """
+    start = datetime.now()
     in_dir = in_dir.resolve(strict=True)
     if date_time is None:
         st = in_dir.stat()
@@ -140,7 +156,10 @@ def dir2zip(in_dir: Path, zip_fname: Path, date_time: datetime | None = None) ->
                 zinfo.date_time = date_time_args
                 zinfo.compress_type = compression
                 with open(fname, "rb") as fp:
-                    z.writestr(zinfo, fp.read())
+                    z.writestr(zinfo, fp.read(), compresslevel=_COMPRESS_LEVEL)
+    logger.debug(
+        "dir2zip from %s to %s takes %s", in_dir, zip_fname, datetime.now() - start
+    )
 
 
 def tarbz2todir(tarbz2_fname: Path, out_dir: Path) -> None:
@@ -157,11 +176,14 @@ class EnvironmentDefault(argparse.Action):
         required: bool = True,
         default: str | None = None,
         choices: Iterable[str] | None = None,
+        type: type | None = None,
         **kwargs: Any,
     ) -> None:
         self.env_default = os.environ.get(env)
         self.env = env
         if self.env_default:
+            if type:
+                self.env_default = type(self.env_default)
             default = self.env_default
         if default:
             required = False

--- a/src/auditwheel/wheeltools.py
+++ b/src/auditwheel/wheeltools.py
@@ -15,9 +15,7 @@ from datetime import datetime, timezone
 from itertools import product
 from os.path import splitext
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from types import TracebackType
-from typing import Any, ClassVar
 
 from packaging.utils import parse_wheel_filename
 
@@ -100,12 +98,7 @@ class InWheel(InTemporaryDirectory):
     On entering, you'll find yourself in the root tree of the wheel.  If you've
     asked for an output wheel, then on exit we'll rewrite the wheel record and
     pack stuff up for you.
-
-    If `out_wheel` is None, we assume the wheel won't be modified and we can
-    cache the unpacked wheel for future use.
     """
-
-    _whl_cache: ClassVar[dict[Path, TemporaryDirectory[Any]]] = {}
 
     def __init__(self, in_wheel: Path, out_wheel: Path | None = None) -> None:
         """Initialize in-wheel context manager
@@ -120,35 +113,9 @@ class InWheel(InTemporaryDirectory):
         """
         self.in_wheel = in_wheel.absolute()
         self.out_wheel = None if out_wheel is None else out_wheel.absolute()
-        self.read_only = out_wheel is None
-        self.use_cache = self.in_wheel in self._whl_cache
-        if self.use_cache and not Path(self._whl_cache[self.in_wheel].name).exists():
-            self.use_cache = False
-            logger.debug(
-                "Wheel ctx %s for %s is no longer valid",
-                self._whl_cache.pop(self.in_wheel),
-                self.in_wheel,
-            )
-
-        if self.use_cache:
-            logger.debug(
-                "Reuse %s for %s", self._whl_cache[self.in_wheel], self.in_wheel
-            )
-            self._tmpdir = self._whl_cache[self.in_wheel]
-            if not self.read_only:
-                self._whl_cache.pop(self.in_wheel)
-        else:
-            super().__init__()
-            if self.read_only:
-                self._whl_cache[self.in_wheel] = self._tmpdir
+        super().__init__()
 
     def __enter__(self) -> Path:
-        if self.use_cache or self.read_only:
-            if not self.use_cache:
-                zip2dir(self.in_wheel, self.name)
-            self._pwd = Path.cwd()
-            os.chdir(self.name)
-            return Path(self.name)
         zip2dir(self.in_wheel, self.name)
         return super().__enter__()
 
@@ -165,16 +132,6 @@ class InWheel(InTemporaryDirectory):
             if timestamp:
                 date_time = datetime.fromtimestamp(int(timestamp), tz=timezone.utc)
             dir2zip(self.name, self.out_wheel, date_time)
-        if self.use_cache or self.read_only:
-            logger.debug(
-                "Exiting reused %s for %s",
-                self._whl_cache[self.in_wheel],
-                self.in_wheel,
-            )
-            os.chdir(self._pwd)
-            if not self.read_only:
-                super().__exit__(exc, value, tb)
-            return None
         return super().__exit__(exc, value, tb)
 
 

--- a/src/auditwheel/wheeltools.py
+++ b/src/auditwheel/wheeltools.py
@@ -9,6 +9,7 @@ import csv
 import hashlib
 import logging
 import os
+import zlib
 from base64 import urlsafe_b64encode
 from collections.abc import Generator, Iterable
 from datetime import datetime, timezone
@@ -113,6 +114,7 @@ class InWheel(InTemporaryDirectory):
         """
         self.in_wheel = in_wheel.absolute()
         self.out_wheel = None if out_wheel is None else out_wheel.absolute()
+        self.zip_compression_level = zlib.Z_DEFAULT_COMPRESSION
         super().__init__()
 
     def __enter__(self) -> Path:
@@ -131,7 +133,7 @@ class InWheel(InTemporaryDirectory):
             timestamp = os.environ.get("SOURCE_DATE_EPOCH")
             if timestamp:
                 date_time = datetime.fromtimestamp(int(timestamp), tz=timezone.utc)
-            dir2zip(self.name, self.out_wheel, date_time)
+            dir2zip(self.name, self.out_wheel, self.zip_compression_level, date_time)
         return super().__exit__(exc, value, tb)
 
 

--- a/tests/integration/test_bundled_wheels.py
+++ b/tests/integration/test_bundled_wheels.py
@@ -138,6 +138,7 @@ def test_wheel_source_date_epoch(tmp_path, monkeypatch):
         func=Mock(),
         prog="auditwheel",
         verbose=1,
+        zip=None,
     )
     monkeypatch.setenv("SOURCE_DATE_EPOCH", "650203200")
     # patchelf might not be available as we aren't running in a manylinux container

--- a/tests/integration/test_bundled_wheels.py
+++ b/tests/integration/test_bundled_wheels.py
@@ -134,11 +134,11 @@ def test_wheel_source_date_epoch(tmp_path, monkeypatch):
         WHEEL_FILE=[wheel_path],
         EXCLUDE=[],
         DISABLE_ISA_EXT_CHECK=False,
+        ZIP_COMPRESSION_LEVEL=6,
         cmd="repair",
         func=Mock(),
         prog="auditwheel",
         verbose=1,
-        zip=None,
     )
     monkeypatch.setenv("SOURCE_DATE_EPOCH", "650203200")
     # patchelf might not be available as we aren't running in a manylinux container

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -68,16 +68,16 @@ def test_zip_environment_action(
     choices = _all_zip_level
     argv = []
     if passed is not None:
-        argv = ["--zip-level", str(passed)]
+        argv = ["--zip-compression-level", str(passed)]
     if environ is not None:
-        monkeypatch.setenv("AUDITWHEEL_ZIP_LEVEL", str(environ))
+        monkeypatch.setenv("AUDITWHEEL_ZIP_COMPRESSION_LEVEL", str(environ))
     p = argparse.ArgumentParser()
     p.add_argument(
         "-z",
         "--zip-level",
         action=EnvironmentDefault,
         metavar="zip",
-        env="AUDITWHEEL_ZIP_LEVEL",
+        env="AUDITWHEEL_ZIP_COMPRESSION_LEVEL",
         dest="zip",
         type=int,
         help="Compress level to be used to create zip file.",
@@ -105,29 +105,29 @@ def test_environment_action_invalid_plat_env(monkeypatch: pytest.MonkeyPatch) ->
 
 def test_environment_action_invalid_zip_env(monkeypatch: pytest.MonkeyPatch) -> None:
     choices = _all_zip_level
-    monkeypatch.setenv("AUDITWHEEL_ZIP_LEVEL", "foo")
+    monkeypatch.setenv("AUDITWHEEL_ZIP_COMPRESSION_LEVEL", "foo")
     p = argparse.ArgumentParser()
     with pytest.raises(argparse.ArgumentError):
         p.add_argument(
             "-z",
-            "--zip-level",
+            "--zip-compression-level",
             action=EnvironmentDefault,
             metavar="zip",
-            env="AUDITWHEEL_ZIP_LEVEL",
+            env="AUDITWHEEL_ZIP_COMPRESSION_LEVEL",
             dest="zip",
             type=int,
             help="Compress level to be used to create zip file.",
             choices=choices,
             default=zlib.Z_DEFAULT_COMPRESSION,
         )
-    monkeypatch.setenv("AUDITWHEEL_ZIP_LEVEL", "10")
+    monkeypatch.setenv("AUDITWHEEL_ZIP_COMPRESSION_LEVEL", "10")
     with pytest.raises(argparse.ArgumentError):
         p.add_argument(
             "-z",
-            "--zip-level",
+            "--zip-compression-level",
             action=EnvironmentDefault,
             metavar="zip",
-            env="AUDITWHEEL_ZIP_LEVEL",
+            env="AUDITWHEEL_ZIP_COMPRESSION_LEVEL",
             dest="zip",
             type=int,
             help="Compress level to be used to create zip file.",

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -169,7 +169,7 @@ def test_zip2dir_round_trip_permissions(tmp_path: Path) -> None:
     _write_test_permissions_zip(source_zip)
     extract_path = tmp_path / "unzip2"
     zip2dir(source_zip, tmp_path / "unzip1")
-    dir2zip(tmp_path / "unzip1", tmp_path / "tmp.zip")
+    dir2zip(tmp_path / "unzip1", tmp_path / "tmp.zip", zlib.Z_DEFAULT_COMPRESSION, None)
     zip2dir(tmp_path / "tmp.zip", extract_path)
     _check_permissions(extract_path)
 
@@ -181,7 +181,7 @@ def test_dir2zip_deflate(tmp_path: Path) -> None:
     input_file = input_dir / "zeros.bin"
     input_file.write_bytes(buffer)
     output_file = tmp_path / "ouput.zip"
-    dir2zip(input_dir, output_file)
+    dir2zip(input_dir, output_file, zlib.Z_DEFAULT_COMPRESSION, None)
     assert output_file.stat().st_size < len(buffer) / 4
 
 
@@ -194,7 +194,7 @@ def test_dir2zip_folders(tmp_path: Path) -> None:
     empty_folder = input_dir / "dummy" / "empty"
     empty_folder.mkdir(parents=True)
     output_file = tmp_path / "output.zip"
-    dir2zip(input_dir, output_file)
+    dir2zip(input_dir, output_file, zlib.Z_DEFAULT_COMPRESSION, None)
     expected_dirs = {"dummy/", "dummy/empty/", "dummy-1.0.dist-info/"}
     with zipfile.ZipFile(output_file, "r") as z:
         assert len(z.filelist) == 4

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -74,7 +74,7 @@ def test_zip_environment_action(
     p = argparse.ArgumentParser()
     p.add_argument(
         "-z",
-        "--zip-level",
+        "--zip-compression-level",
         action=EnvironmentDefault,
         metavar="zip",
         env="AUDITWHEEL_ZIP_COMPRESSION_LEVEL",

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import lzma
 import zipfile
+import zlib
 from pathlib import Path
 
 import pytest
@@ -44,7 +45,7 @@ def test_environment_action(
     assert expected == args.PLAT
 
 
-def test_environment_action_invalid_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_environment_action_invalid_plat_env(monkeypatch: pytest.MonkeyPatch) -> None:
     choices = ["linux", "manylinux1", "manylinux2010"]
     monkeypatch.setenv("AUDITWHEEL_PLAT", "foo")
     p = argparse.ArgumentParser()
@@ -56,6 +57,39 @@ def test_environment_action_invalid_env(monkeypatch: pytest.MonkeyPatch) -> None
             dest="PLAT",
             choices=choices,
             default="manylinux1",
+        )
+
+
+def test_environment_action_invalid_zip_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    choices = list(range(zlib.Z_NO_COMPRESSION, zlib.Z_BEST_COMPRESSION + 1))
+    monkeypatch.setenv("AUDITWHEEL_ZIP_LEVEL", "foo")
+    p = argparse.ArgumentParser()
+    with pytest.raises(argparse.ArgumentError):
+        p.add_argument(
+            "-z",
+            "--zip-level",
+            action=EnvironmentDefault,
+            metavar="zip",
+            env="AUDITWHEEL_ZIP_LEVEL",
+            dest="zip",
+            type=int,
+            help="Compress level to be used to create zip file.",
+            choices=choices,
+            default=zlib.Z_DEFAULT_COMPRESSION,
+        )
+    monkeypatch.setenv("AUDITWHEEL_ZIP_LEVEL", "10")
+    with pytest.raises(argparse.ArgumentError):
+        p.add_argument(
+            "-z",
+            "--zip-level",
+            action=EnvironmentDefault,
+            metavar="zip",
+            env="AUDITWHEEL_ZIP_LEVEL",
+            dest="zip",
+            type=int,
+            help="Compress level to be used to create zip file.",
+            choices=choices,
+            default=zlib.Z_DEFAULT_COMPRESSION,
         )
 
 


### PR DESCRIPTION
Add `--zip-compression-level` and `AUDITWHEEL_ZIP_COMPRESSION_LEVEL` env to specify zip compression level.

This PR do not change the default level.

Part of #545.
As in https://github.com/pypa/auditwheel/pull/545#issuecomment-2676697741, we don't want to alter the default compress level. However I do want to add this argument to have the ability to change it.

I'm not very sure about the best place to add test for this.