### PR TITLE
Add libatomic.so.1 to lib_whitelist

### DIFF
--- a/src/auditwheel/policy/manylinux-policy.json
+++ b/src/auditwheel/policy/manylinux-policy.json
@@ -331,7 +331,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9"]
       }
     },
-    "lib_whitelist": ["libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1", "libatomic.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "bi_windup", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "crc_fold_512to32", "crc_fold_copy", "crc_fold_init", "deflate_copyright", "deflate_medium", "fill_window", "flush_pending", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "longest_match", "slide_hash_sse", "static_ltree", "uncompress2", "x86_check_features", "x86_cpu_has_pclmul", "x86_cpu_has_sse2", "x86_cpu_has_sse42", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -391,7 +391,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9"]
       }
     },
-    "lib_whitelist": ["libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1", "libatomic.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "bi_windup", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "crc_fold_512to32", "crc_fold_copy", "crc_fold_init", "deflate_copyright", "deflate_medium", "fill_window", "flush_pending", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "longest_match", "slide_hash_sse", "static_ltree", "x86_check_features", "x86_cpu_has_pclmul", "x86_cpu_has_sse2", "x86_cpu_has_sse42", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -451,7 +451,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9"]
       }
     },
-    "lib_whitelist": ["libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1", "libatomic.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "bi_windup", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "crc_fold_512to32", "crc_fold_copy", "crc_fold_init", "deflate_copyright", "deflate_medium", "fill_window", "flush_pending", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "longest_match", "slide_hash_sse", "static_ltree", "x86_check_features", "x86_cpu_has_pclmul", "x86_cpu_has_sse2", "x86_cpu_has_sse42", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -518,7 +518,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9"]
       }
     },
-    "lib_whitelist": ["libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1", "libatomic.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "deflate_copyright", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -585,7 +585,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9", "1.2.12"]
       }
     },
-    "lib_whitelist": ["libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1", "libatomic.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "crc32_acle", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "deflate_copyright", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -652,7 +652,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9", "1.2.12"]
       }
     },
-    "lib_whitelist": ["libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1", "libatomic.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "crc32_acle", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "deflate_copyright", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -719,7 +719,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9", "1.2.12"]
       }
     },
-    "lib_whitelist": ["libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1", "libatomic.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "crc32_acle", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "deflate_copyright", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }


### PR DESCRIPTION
On RISC-V, GCC 12 and earlier require libatomic support for 1-byte and 2-byte operations, which have been a long and painful story. [1][2][3][4]

Users' machine definitely will have the libatomic library to make softwares work, so adding this should be safe.

This seems also to be an regression on cpython 3.13 with more architectures than riscv64. [5]

[1] https://github.com/riscvarchive/riscv-gcc/issues/12
[2] https://github.com/riscvarchive/riscv-gcc/issues/337
[3] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86005
[4] https://github.com/python/cpython/issues/112779
[5] https://github.com/python/cpython/issues/127708