### PR TITLE
lddtree: support alternative LD_LIBRARY_PATH called AUDITWHEEL_LD_LIBRARY_PATH

### DIFF
--- a/src/auditwheel/lddtree.py
+++ b/src/auditwheel/lddtree.py
@@ -318,7 +318,7 @@ def load_ld_paths(
     ldpaths: dict[str, list[str]] = {"conf": [], "env": [], "interp": []}
 
     # Load up $LD_LIBRARY_PATH.
-    env_ldpath = os.environ.get("LD_LIBRARY_PATH")
+    env_ldpath = os.environ.get("AUDITWHEEL_LD_LIBRARY_PATH", default=os.environ.get("LD_LIBRARY_PATH"))
     if env_ldpath is not None:
         if root != "/":
             log.warning("ignoring LD_LIBRARY_PATH due to ROOT usage")

--- a/tests/integration/test_bundled_wheels.py
+++ b/tests/integration/test_bundled_wheels.py
@@ -77,6 +77,60 @@ def test_analyze_wheel_abi(file, external_libs, exclude):
     if modify_ld_library_path:
         importlib.reload(lddtree)
 
+@pytest.mark.parametrize(
+    ("file", "external_libs", "exclude"),
+    [
+        ("cffi-1.5.0-cp27-none-linux_x86_64.whl", {"libffi.so.5"}, frozenset()),
+        ("cffi-1.5.0-cp27-none-linux_x86_64.whl", set(), frozenset(["libffi.so.5"])),
+        (
+            "cffi-1.5.0-cp27-none-linux_x86_64.whl",
+            {"libffi.so.5"},
+            frozenset(["libffi.so.noexist", "libnoexist.so.*"]),
+        ),
+        (
+            "cffi-1.5.0-cp27-none-linux_x86_64.whl",
+            set(),
+            frozenset(["libffi.so.[4,5]"]),
+        ),
+        (
+            "cffi-1.5.0-cp27-none-linux_x86_64.whl",
+            {"libffi.so.5"},
+            frozenset(["libffi.so.[6,7]"]),
+        ),
+        (
+            "cffi-1.5.0-cp27-none-linux_x86_64.whl",
+            set(),
+            frozenset([f"{HERE}/*"]),
+        ),
+        ("cffi-1.5.0-cp27-none-linux_x86_64.whl", set(), frozenset(["libffi.so.*"])),
+        ("cffi-1.5.0-cp27-none-linux_x86_64.whl", set(), frozenset(["*"])),
+        (
+            "python_snappy-0.5.2-pp260-pypy_41-linux_x86_64.whl",
+            {"libsnappy.so.1"},
+            frozenset(),
+        ),
+    ],
+)
+def test_analyze_wheel_abi_awllp(file, external_libs, exclude):
+    # Test that AUDITWHEEL_LD_LIBRARY_PATH takes precedence
+    modify_ld_library_path = any(isabs(e) for e in exclude)
+
+    with pytest.MonkeyPatch.context() as cp:
+        if modify_ld_library_path:
+            cp.setenv("LD_LIBRARY_PATH", f"NOTHERE")
+            cp.setenv("AUDITWHEEL_LD_LIBRARY_PATH", f"{HERE}")
+            importlib.reload(lddtree)
+
+        winfo = analyze_wheel_abi(
+            Libc.GLIBC, Architecture.x86_64, HERE / file, exclude, False, True
+        )
+        assert set(winfo.external_refs["manylinux_2_5_x86_64"].libs) == external_libs, (
+            f"{HERE}, {exclude}, {os.environ}"
+        )
+
+    if modify_ld_library_path:
+        importlib.reload(lddtree)
+
 
 def test_analyze_wheel_abi_pyfpe():
     winfo = analyze_wheel_abi(


### PR DESCRIPTION
Sometimes wheels are different only just by shared libraries that are
vendored in. Sometimes the wheel being repaired and the libraries that
need to be vendored in are accessible on the host that was not used
for building the wheel. In such cases, it could be the case that
shared libraries used by python that is executing the auditwheel
script, are incompatible (too old or too new) than those that need to
be vendored.

In such cases, LD_LIBRARY_PATH is not convenient to use, as the python
interpreter for the auditwheel script is crashing.

Add an AUDITWHEEL_LD_LIBRARY_PATH whichis used by lddtree, but
otherwise does not affect the python interpreter executing auditwheel
script.

This helps vendoring in older libraries from an alternative path, into
a wheel built against an older python, whilst otherwise running
auditwheel repair on a modern system with a much newer python. This is
particularly useful when stripping a wheel of vendored libraries, and
repair it again to update the shared library dependencies coming from
an unpacked chroot.

Separately it also helps creating alternative wheels with shared
libraries rebuilt with higher march settings. Given that python
upstream doesn't support loading optimised libraries as has been
implemented and supported in Intel ClearLinux Python which allows one
to have alternative march setting shared library deps.
