### PR TITLE
fix: tests using cython on manylinux_2_5

### DIFF
--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -454,6 +454,10 @@ class Anylinux:
         for key in os.environ:
             if key.startswith("COV_CORE_"):
                 env[key] = os.environ[key]
+        # cython 3.1.0+ requires a C99 compiler,
+        # where manylinux_2_5 uses gcc 4.8 which is not C99 compliant by default.
+        if policy == "manylinux_2_5":
+            env["CFLAGS"] = "-std=c99"
 
         with docker_container_ctx(manylinux_img, io_folder, env) as container:
             platform_tag = ".".join(


### PR DESCRIPTION
cython 3.1.0+ requires a C99 compiler but manylinux_2_5 uses gcc 4.8 which is not C99 compliant by default.