### PR TITLE
fix: respect `DT_NEEDED` entries order in `lddtree`

### DIFF
--- a/src/auditwheel/lddtree.py
+++ b/src/auditwheel/lddtree.py
@@ -75,7 +75,7 @@ class DynamicLibrary:
     path: str | None
     realpath: Path | None
     platform: Platform | None = None
-    needed: frozenset[str] = frozenset()
+    needed: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -85,7 +85,7 @@ class DynamicExecutable:
     path: str
     realpath: Path
     platform: Platform
-    needed: frozenset[str]
+    needed: tuple[str, ...]
     rpath: tuple[str, ...]
     runpath: tuple[str, ...]
     libraries: dict[str, DynamicLibrary]
@@ -447,7 +447,7 @@ def ldd(
 
     interpreter: str | None = None
     libc: Libc | None = None
-    needed: set[str] = set()
+    needed: list[str] = []
     rpaths: list[str] = []
     runpaths: list[str] = []
 
@@ -496,7 +496,7 @@ def ldd(
                 elif t.entry.d_tag == "DT_RUNPATH":
                     runpaths = parse_ld_paths(t.runpath, path=str(path), root=root)
                 elif t.entry.d_tag == "DT_NEEDED":
-                    needed.add(t.needed)
+                    needed.append(t.needed)
             if runpaths:
                 # If both RPATH and RUNPATH are set, only the latter is used.
                 rpaths = []
@@ -586,7 +586,7 @@ def ldd(
         str(path) if display is None else display,
         path,
         platform,
-        frozenset(needed - _excluded_libs),
+        tuple(soname for soname in needed if soname not in _excluded_libs),
         tuple(rpaths),
         tuple(runpaths),
         _all_libs,

--- a/src/auditwheel/policy/__init__.py
+++ b/src/auditwheel/policy/__init__.py
@@ -4,7 +4,7 @@ import json
 import logging
 import re
 from collections import defaultdict
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -192,7 +192,7 @@ class WheelPolicies:
         self, lddtree: DynamicExecutable, wheel_path: Path
     ) -> dict[str, ExternalReference]:
         def filter_libs(
-            libs: frozenset[str], whitelist: frozenset[str]
+            libs: Iterable[str], whitelist: frozenset[str]
         ) -> Generator[str]:
             for lib in libs:
                 if "ld-linux" in lib or lib in ["ld64.so.2", "ld64.so.1"]:
@@ -232,7 +232,7 @@ class WheelPolicies:
                 # whitelist is the complete set of all libraries. so nothing
                 # is considered "external" that needs to be copied in.
                 whitelist = p.whitelist
-                blacklist_libs = set(p.blacklist.keys()) & lddtree.needed
+                blacklist_libs = set(p.blacklist.keys()) & set(lddtree.needed)
                 blacklist_reduced = {k: p.blacklist[k] for k in blacklist_libs}
                 blacklist = filter_undefined_symbols(
                     lddtree.realpath, blacklist_reduced

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -187,7 +187,7 @@ class TestLddTreeExternalReferences:
             platform=Platform(
                 "", 64, True, "EM_X86_64", Architecture.x86_64, None, None
             ),
-            needed=frozenset(libs),
+            needed=tuple(libs),
             libraries={
                 lib: DynamicLibrary(lib, f"/path/to/{lib}", Path(f"/path/to/{lib}"))
                 for lib in libs


### PR DESCRIPTION
This order was changed and not unreliable since it's using an unordered set in 6.3.0