### PR TITLE
manylinux-policy: allow glibc component libanl

### DIFF
--- a/src/auditwheel/policy/manylinux-policy.json
+++ b/src/auditwheel/policy/manylinux-policy.json
@@ -29,7 +29,7 @@
         "ZLIB": []
       }
     },
-    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libz.so.1"],
+    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libanl.so.1", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libz.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "bi_windup", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "crc_fold_512to32", "crc_fold_copy", "crc_fold_init", "deflate_copyright", "deflate_medium", "fill_window", "flush_pending", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "longest_match", "slide_hash_sse", "static_ltree", "uncompress2", "x86_check_features", "x86_cpu_has_pclmul", "x86_cpu_has_sse2", "x86_cpu_has_sse42", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -56,7 +56,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4"]
       }
     },
-    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libanl.so.1", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "bi_windup", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "crc_fold_512to32", "crc_fold_copy", "crc_fold_init", "deflate_copyright", "deflate_medium", "fill_window", "flush_pending", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "longest_match", "slide_hash_sse", "static_ltree", "uncompress2", "x86_check_features", "x86_cpu_has_pclmul", "x86_cpu_has_sse2", "x86_cpu_has_sse42", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -123,7 +123,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2"]
       }
     },
-    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libanl.so.1", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "bi_windup", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "crc_fold_512to32", "crc_fold_copy", "crc_fold_init", "deflate_copyright", "deflate_medium", "fill_window", "flush_pending", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "longest_match", "slide_hash_sse", "static_ltree", "uncompress2", "x86_check_features", "x86_cpu_has_pclmul", "x86_cpu_has_sse2", "x86_cpu_has_sse42", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -182,7 +182,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2"]
       }
     },
-    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libanl.so.1", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "bi_windup", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "crc_fold_512to32", "crc_fold_copy", "crc_fold_init", "deflate_copyright", "deflate_medium", "fill_window", "flush_pending", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "longest_match", "slide_hash_sse", "static_ltree", "uncompress2", "x86_check_features", "x86_cpu_has_pclmul", "x86_cpu_has_sse2", "x86_cpu_has_sse42", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -241,7 +241,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9"]
       }
     },
-    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libanl.so.1", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "bi_windup", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "crc_fold_512to32", "crc_fold_copy", "crc_fold_init", "deflate_copyright", "deflate_medium", "fill_window", "flush_pending", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "longest_match", "slide_hash_sse", "static_ltree", "uncompress2", "x86_check_features", "x86_cpu_has_pclmul", "x86_cpu_has_sse2", "x86_cpu_has_sse42", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -300,7 +300,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9"]
       }
     },
-    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libanl.so.1", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "bi_windup", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "crc_fold_512to32", "crc_fold_copy", "crc_fold_init", "deflate_copyright", "deflate_medium", "fill_window", "flush_pending", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "longest_match", "slide_hash_sse", "static_ltree", "uncompress2", "x86_check_features", "x86_cpu_has_pclmul", "x86_cpu_has_sse2", "x86_cpu_has_sse42", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -359,7 +359,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9"]
       }
     },
-    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libanl.so.1", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "bi_windup", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "crc_fold_512to32", "crc_fold_copy", "crc_fold_init", "deflate_copyright", "deflate_medium", "fill_window", "flush_pending", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "longest_match", "slide_hash_sse", "static_ltree", "uncompress2", "x86_check_features", "x86_cpu_has_pclmul", "x86_cpu_has_sse2", "x86_cpu_has_sse42", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -426,7 +426,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9"]
       }
     },
-    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libanl.so.1", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "bi_windup", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "crc_fold_512to32", "crc_fold_copy", "crc_fold_init", "deflate_copyright", "deflate_medium", "fill_window", "flush_pending", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "longest_match", "slide_hash_sse", "static_ltree", "uncompress2", "x86_check_features", "x86_cpu_has_pclmul", "x86_cpu_has_sse2", "x86_cpu_has_sse42", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -493,7 +493,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9"]
       }
     },
-    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libanl.so.1", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "bi_windup", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "crc_fold_512to32", "crc_fold_copy", "crc_fold_init", "deflate_copyright", "deflate_medium", "fill_window", "flush_pending", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "longest_match", "slide_hash_sse", "static_ltree", "x86_check_features", "x86_cpu_has_pclmul", "x86_cpu_has_sse2", "x86_cpu_has_sse42", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -560,7 +560,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9"]
       }
     },
-    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libanl.so.1", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "bi_windup", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "crc_fold_512to32", "crc_fold_copy", "crc_fold_init", "deflate_copyright", "deflate_medium", "fill_window", "flush_pending", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "longest_match", "slide_hash_sse", "static_ltree", "x86_check_features", "x86_cpu_has_pclmul", "x86_cpu_has_sse2", "x86_cpu_has_sse42", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -635,7 +635,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9"]
       }
     },
-    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libanl.so.1", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "crc32_acle", "crc32_combine_gen", "crc32_combine_gen64", "crc32_combine_op", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "deflate_copyright", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -710,7 +710,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9", "1.2.12"]
       }
     },
-    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libanl.so.1", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "crc32_acle", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "deflate_copyright", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -785,7 +785,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9", "1.2.12"]
       }
     },
-    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libanl.so.1", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "crc32_acle", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "deflate_copyright", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }
@@ -860,7 +860,7 @@
         "ZLIB": ["1.2.0", "1.2.0.2", "1.2.0.8", "1.2.2", "1.2.2.3", "1.2.2.4", "1.2.3.3", "1.2.3.4", "1.2.3.5", "1.2.5.1", "1.2.5.2", "1.2.7.1", "1.2.9", "1.2.12"]
       }
     },
-    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
+    "lib_whitelist": ["libatomic.so.1", "libgcc_s.so.1", "libstdc++.so.6", "libm.so.6", "libanl.so.1", "libdl.so.2", "librt.so.1", "libc.so.6", "libnsl.so.1", "libutil.so.1", "libpthread.so.0", "libX11.so.6", "libXext.so.6", "libXrender.so.1", "libICE.so.6", "libSM.so.6", "libGL.so.1", "libgobject-2.0.so.0", "libgthread-2.0.so.0", "libglib-2.0.so.0", "libresolv.so.2", "libexpat.so.1", "libz.so.1"],
     "blacklist": {
       "libz.so.1": ["_dist_code", "_length_code", "_tr_align", "_tr_flush_block", "_tr_init", "_tr_stored_block", "_tr_tally", "adler32_default", "crc32_acle", "crc32_le_vgfm_16", "crc32_neon", "crc32_vpmsum", "crc32_z_default", "deflate_copyright", "gzflags", "inflate_copyright", "inflate_fast", "inflate_table", "z_errmsg", "z_vstring", "zcalloc", "zcfree"]
     }


### PR DESCRIPTION
libanl was addedd to resolv in glibc 2.2.5 in 2001 to support async
dns queries.

It uses private GLIBC symbols, thus to ensure it works with higher
glibc runtime versions, it must be shared linked and should not be
vendored into the wheels. (similar to libdl / dlopen)

In 2021 with glibc 2.34 similar to many other split libraries, libanl
got folded into libc itself, and thus any applications that use async
dns queries no longer gain libanl NEEDED shared library dependency
with a stub remaining in place. (similar to libdl / libpthread etc).

Thus for policies between 2.2.5 and 2.33 there is a need to allow list
libanl, for example when vendoring modern builds of icu.

Longer term, it would be interested to support dropping libraries,
because policies built to manylinux 2.34 policy really should no
longer link with libanl / libdl / libpthread etc. As in all of those
libraries have now become no-op stubs.
