### PR TITLE
fix: architecture tests on 32-bit x86

### DIFF
--- a/tests/integration/test_bundled_wheels.py
+++ b/tests/integration/test_bundled_wheels.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib
 import os
-import platform
 import sys
 import zipfile
 from argparse import Namespace
@@ -108,7 +107,7 @@ def test_analyze_wheel_abi_pyfpe():
 def test_show_wheel_abi_pyfpe(monkeypatch, capsys):
     wheel = str(HERE / "fpewheel-0.0.0-cp35-cp35m-linux_x86_64.whl")
     monkeypatch.setattr(sys, "platform", "linux")
-    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(Architecture, "detect", lambda: Architecture.x86_64)
     monkeypatch.setattr(sys, "argv", ["auditwheel", "show", wheel])
     assert main() == 0
     captured = capsys.readouterr()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import platform
 import sys
 
 import pytest
 
+from auditwheel.architecture import Architecture
 from auditwheel.libc import Libc, LibcVersion
 from auditwheel.main import main
 
@@ -41,7 +41,7 @@ def test_help(monkeypatch, capsys):
 @pytest.mark.parametrize("function", ["show", "repair"])
 def test_unexisting_wheel(monkeypatch, capsys, tmp_path, function):
     monkeypatch.setattr(sys, "platform", "linux")
-    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(Architecture, "detect", lambda: Architecture.x86_64)
     wheel = str(tmp_path / "not-a-file.whl")
     monkeypatch.setattr(sys, "argv", ["auditwheel", function, wheel])
 
@@ -79,7 +79,7 @@ def test_repair_wheel_mismatch(
     monkeypatch, capsys, tmp_path, libc, filename, plat, message
 ):
     monkeypatch.setattr(sys, "platform", "linux")
-    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(Architecture, "detect", lambda: Architecture.x86_64)
     monkeypatch.setattr(Libc, "detect", lambda: libc)
     monkeypatch.setattr(Libc, "get_current_version", lambda _: LibcVersion(1, 1))
     wheel = tmp_path / filename


### PR DESCRIPTION
Some tests that involved monkey-patching architecture detection failed on 32-bit x86 (as seen in e.g.
https://ci.debian.net/packages/p/python-auditwheel/testing/i386/66694877/), because they tried to set the architecture by monkey-patching `platform.machine`, but `Architecture.detect` also cares about the size of pointers.  It's simpler and more reliable to just monkey-patch `Architecture.detect` directly in these cases.