### PR TITLE
fix: handle argparse changes in Python 3.14

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -31,6 +31,7 @@ def test_unsupported_platform(monkeypatch):
 def test_help(monkeypatch, capsys):
     # GIVEN
     monkeypatch.setattr(sys, "argv", ["auditwheel"])
+    # handle running tests using 'python -m pytest' rather than just 'pytest' on Python 3.14+
     monkeypatch.delattr(sys.modules.get("__main__"), "__spec__", raising=False)
 
     # WHEN


### PR DESCRIPTION
https://github.com/python/cpython/issues/66436 causes `tests/unit/test_main.py::test_help` to fail on Python 3.14 as follows:

```
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7f549ac59a70>, capsys = <_pytest.capture.CaptureFixture object at 0x7f549ad9e660>

    @on_supported_platform
    def test_help(monkeypatch, capsys):
        # GIVEN
        monkeypatch.setattr(sys, "argv", ["auditwheel"])

        # WHEN
        retval = main()

        # THEN
        assert retval is None
        captured = capsys.readouterr()
>       assert "usage: auditwheel [-h] [-V] [-v] command ..." in captured.out
E       assert 'usage: auditwheel [-h] [-V] [-v] command ...' in "usage: python3.14 -m pytest [-h] [-V] [-v] command ...\n\nCross-distro Python wheels.\n\npositional arguments:\n  command\n    show         Audit a wheel for external shared library dependencies.\n    repair       Vendor in external shared library dependencies of a wheel. If\n                 multiple wheels are specified, an error processing one wheel\n                 will abort processing of subsequent wheels.\n    lddtree      Analyze a single ELF file (similar to ``ldd``).\n\noptions:\n  -h, --help     show this help message and exit\n  -V, --version  show program's version number and exit\n  -v, --verbose  Give more output. Option is additive\n"
E        +  where "usage: python3.14 -m pytest [-h] [-V] [-v] command ...\n\nCross-distro Python wheels.\n\npositional arguments:\n  command\n    show         Audit a wheel for external shared library dependencies.\n    repair       Vendor in external shared library dependencies of a wheel. If\n                 multiple wheels are specified, an error processing one wheel\n                 will abort processing of subsequent wheels.\n    lddtree      Analyze a single ELF file (similar to ``ldd``).\n\noptions:\n  -h, --help     show this help message and exit\n  -V, --version  show program's version number and exit\n  -v, --verbose  Give more output. Option is additive\n" = CaptureResult(out="usage: python3.14 -m pytest [-h] [-V] [-v] command ...\n\nCross-distro Python wheels.\n\npositional arguments:\n  command\n    show         Audit a wheel for external shared library dependencies.\n    repair       Vendor in external shared library dependencies of a wheel. If\n                 multiple wheels are specified, an error processing one wheel\n                 will abort processing of subsequent wheels.\n    lddtree      Analyze a single ELF file (similar to ``ldd``).\n\noptions:\n  -h, --help     show this help message and exit\n  -V, --version  show program's version number and exit\n  -v, --verbose  Give more output. Option is additive\n", err='').out

tests/unit/test_main.py:41: AssertionError
```

Monkey-patch things a bit harder so that the output is as we expect.