### PR TITLE
fix: non python ELF tree dependencies resolution

### DIFF
--- a/src/auditwheel/lddtree.py
+++ b/src/auditwheel/lddtree.py
@@ -92,6 +92,19 @@ class DynamicExecutable:
     runpath: tuple[str, ...]
     libraries: dict[str, DynamicLibrary]
 
+    def with_libraries(self, libraries: dict[str, DynamicLibrary]) -> DynamicExecutable:
+        return DynamicExecutable(
+            interpreter=self.interpreter,
+            libc=self.libc,
+            path=self.path,
+            realpath=self.realpath,
+            platform=self.platform,
+            needed=self.needed,
+            rpath=self.rpath,
+            runpath=self.runpath,
+            libraries=libraries,
+        )
+
 
 def _get_platform(elf: ELFFile) -> Platform:
     elf_osabi = elf.header["e_ident"]["EI_OSABI"]

--- a/src/auditwheel/lddtree.py
+++ b/src/auditwheel/lddtree.py
@@ -92,19 +92,6 @@ class DynamicExecutable:
     runpath: tuple[str, ...]
     libraries: dict[str, DynamicLibrary]
 
-    def with_libraries(self, libraries: dict[str, DynamicLibrary]) -> DynamicExecutable:
-        return DynamicExecutable(
-            interpreter=self.interpreter,
-            libc=self.libc,
-            path=self.path,
-            realpath=self.realpath,
-            platform=self.platform,
-            needed=self.needed,
-            rpath=self.rpath,
-            runpath=self.runpath,
-            libraries=libraries,
-        )
-
 
 def _get_platform(elf: ELFFile) -> Platform:
     elf_osabi = elf.header["e_ident"]["EI_OSABI"]

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -58,6 +58,58 @@ class WheelElfData:
     uses_pyfpe_jbuf: bool
 
 
+def _fixup_elf_trees(
+    py_elf_trees: dict[Path, DynamicExecutable],
+    nonpy_elftree: dict[Path, DynamicExecutable],
+) -> None:
+    # Auditwheel assumes that if a dependency in a non-Python ELF tree can be resolved
+    # in any other fully resolved ELF tree, then it can be loaded from other
+    # non-Python ELF trees as well. Python extension ELF trees are not
+    # fixed up; they should always be valid in the first place. We fix up
+    # nonpy_elftree with that assumption in mind.
+    resolved_executables = [
+        executable
+        for executable in itertools.chain(py_elf_trees.values(), nonpy_elftree.values())
+        if all(library.realpath is not None for library in executable.libraries.values())
+    ]
+
+    def _get_reference(path_to_elf: Path) -> DynamicExecutable | None:
+        for candidate in resolved_executables:
+            for library in candidate.libraries.values():
+                assert library.realpath is not None  # noqa: S101
+                if path_to_elf.samefile(library.realpath):
+                    return candidate
+        return None
+
+    for elf_path, elf_executable in nonpy_elftree.items():
+        need_resolution = any(
+            elf_library.realpath is None for elf_library in elf_executable.libraries.values()
+        )
+        if not need_resolution:
+            continue
+        reference = _get_reference(elf_executable.realpath)
+        if reference is None:
+            continue
+        libraries_new: dict[str, DynamicLibrary] = {}
+        soname_all = set(elf_executable.libraries.keys())
+        for soname, elf_library in elf_executable.libraries.items():
+            if elf_library.realpath is None and soname in reference.libraries:
+                libraries_new[soname] = reference.libraries[soname]
+                # we need to add newly found dependencies as well
+                needed_new = set(libraries_new[soname].needed) - soname_all
+                while needed_new:
+                    needed_new_copy = needed_new.copy()
+                    for soname_needed in needed_new_copy:
+                        if soname_needed in reference.libraries:
+                            libraries_new[soname_needed] = reference.libraries[soname_needed]
+                            soname_all.add(soname_needed)
+                            needed_new.update(libraries_new[soname_needed].needed)
+                    needed_new -= soname_all
+            else:
+                libraries_new[soname] = elf_library
+        nonpy_elftree[elf_path] = dataclasses.replace(elf_executable, libraries=libraries_new)
+
+
 @functools.lru_cache
 def get_wheel_elfdata(
     libc: Libc | None,
@@ -165,51 +217,7 @@ def get_wheel_elfdata(
             arch = None if architecture is None else architecture.value
             raise NonPlatformWheelError(arch, shared_libraries_with_invalid_machine)
 
-        # Auditwheel assumes that if a dependency in a non-Python ELF tree can
-        # be resolved in any other ELF tree, then it can be loaded from other
-        # non-Python ELF trees as well. Python extension ELF trees are not
-        # fixed up; they should always be valid in the first place. We fix up
-        # nonpy_elftree with that assumption in mind.
-        soname_library_map: dict[str, DynamicLibrary] = {}
-        for elf_executable in itertools.chain(full_elftree.values(), nonpy_elftree.values()):
-            for soname, elf_library in elf_executable.libraries.items():
-                if soname in soname_library_map:
-                    realpath = soname_library_map[soname].realpath
-                    if realpath is None:
-                        soname_library_map[soname] = elf_library
-                    elif elf_library.realpath is not None and realpath != elf_library.realpath:
-                        msg = (
-                            f"inconsistent ELF trees: {soname!r} can be resolved as "
-                            f"{realpath!r} or {elf_library.realpath!r}"
-                        )
-                        raise ValueError(msg)
-                else:
-                    soname_library_map[soname] = elf_library
-        for elf_path, elf_executable in nonpy_elftree.items():
-            libraries_new: dict[str, DynamicLibrary] = {}
-            soname_all = set(elf_executable.libraries.keys())
-            changed = False
-            for soname, elf_library in elf_executable.libraries.items():
-                if elf_library.realpath is None and soname_library_map[soname].realpath is not None:
-                    libraries_new[soname] = soname_library_map[soname]
-                    # we need to add newly found dependencies as well
-                    needed_new = set(libraries_new[soname].needed) - soname_all
-                    while needed_new:
-                        needed_new_copy = needed_new.copy()
-                        for soname_needed in needed_new_copy:
-                            if soname_needed not in soname_all:
-                                libraries_new[soname_needed] = soname_library_map[soname_needed]
-                                soname_all.add(soname_needed)
-                                needed_new.update(libraries_new[soname_needed].needed)
-                        needed_new -= soname_all
-                    changed = True
-                else:
-                    libraries_new[soname] = elf_library
-            if changed:
-                nonpy_elftree[elf_path] = dataclasses.replace(
-                    elf_executable,
-                    libraries=libraries_new,
-                )
+        _fixup_elf_trees(full_elftree, nonpy_elftree)
 
         # Get a list of all external libraries needed by ELFs in the wheel.
         needed_libs = {

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -77,6 +77,8 @@ def _fixup_elf_trees(
         for candidate in resolved_executables:
             for library in candidate.libraries.values():
                 assert library.realpath is not None  # noqa: S101
+                assert library.realpath.is_file()  # noqa: S101
+                assert path_to_elf.is_file()  # noqa: S101
                 if path_to_elf.samefile(library.realpath):
                     return candidate
         return None
@@ -109,7 +111,8 @@ def _fixup_elf_trees(
                             log.warning("%s not found in %s ELF tree", soname_needed, ref_name)
                     needed_new -= soname_all
             else:
-                log.warning("%s not found in %s ELF tree", soname, ref_name)
+                if elf_library.realpath is None:
+                    log.warning("%s not found in %s ELF tree", soname, ref_name)
                 libraries_new[soname] = elf_library
         nonpy_elftree[elf_path] = dataclasses.replace(elf_executable, libraries=libraries_new)
 

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -66,7 +66,7 @@ def _fixup_elf_trees(
     # in any other fully resolved ELF tree, then it can be loaded from other
     # non-Python ELF trees as well. Python extension ELF trees are not
     # fixed up; they should always be valid in the first place. We fix up
-    # nonpy_elftree with that assumption in mind.
+    # non-Python ELF trees with that assumption in mind.
     resolved_executables = [
         executable
         for executable in itertools.chain(py_elf_trees.values(), nonpy_elftree.values())
@@ -90,6 +90,7 @@ def _fixup_elf_trees(
         reference = _get_reference(elf_executable.realpath)
         if reference is None:
             continue
+        ref_name = reference.realpath.name
         libraries_new: dict[str, DynamicLibrary] = {}
         soname_all = set(elf_executable.libraries.keys())
         for soname, elf_library in elf_executable.libraries.items():
@@ -99,13 +100,16 @@ def _fixup_elf_trees(
                 needed_new = set(libraries_new[soname].needed) - soname_all
                 while needed_new:
                     needed_new_copy = needed_new.copy()
+                    soname_all |= needed_new_copy
                     for soname_needed in needed_new_copy:
                         if soname_needed in reference.libraries:
                             libraries_new[soname_needed] = reference.libraries[soname_needed]
-                            soname_all.add(soname_needed)
                             needed_new.update(libraries_new[soname_needed].needed)
+                        else:
+                            log.warning("%s not found in %s ELF tree", soname_needed, ref_name)
                     needed_new -= soname_all
             else:
+                log.warning("%s not found in %s ELF tree", soname, ref_name)
                 libraries_new[soname] = elf_library
         nonpy_elftree[elf_path] = dataclasses.replace(elf_executable, libraries=libraries_new)
 

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -19,7 +19,7 @@ from auditwheel.elfutils import (
 )
 from auditwheel.error import InvalidLibcError, NonPlatformWheelError
 from auditwheel.genericpkgctx import InGenericPkgCtx
-from auditwheel.lddtree import DynamicExecutable, ldd
+from auditwheel.lddtree import DynamicExecutable, DynamicLibrary, ldd
 from auditwheel.libc import Libc
 from auditwheel.policy import ExternalReference, Policy, WheelPolicies
 
@@ -163,6 +163,33 @@ def get_wheel_elfdata(
         if not platform_wheel:
             arch = None if architecture is None else architecture.value
             raise NonPlatformWheelError(arch, shared_libraries_with_invalid_machine)
+
+        # auditwheel assumes that if a dependency in a non python ELF tree can be resolved in
+        # any other ELF tree then, it can be loaded from other non python ELF trees as well.
+        # Python extensions ELF trees are not fixed up, they should always be valid in the first
+        # place.
+        # we fix-up nonpy_elftree taking that into account
+        soname_library_map: dict[str, DynamicLibrary] = {}
+        for elf_executable in itertools.chain(full_elftree.values(), nonpy_elftree.values()):
+            for soname, elf_library in elf_executable.libraries.items():
+                if elf_library.realpath is not None:
+                    if soname in soname_library_map:
+                        if soname_library_map[soname].realpath != elf_library.realpath:
+                            msg = "inconsistent ELF trees"
+                            raise ValueError(msg)
+                    else:
+                        soname_library_map[soname] = elf_library
+        for elf_path, elf_executable in nonpy_elftree.items():
+            libraries_new: dict[str, DynamicLibrary] = {}
+            changed = False
+            for soname, elf_library in elf_executable.libraries.items():
+                if elf_library.path is None and elf_library.soname in soname_library_map:
+                    libraries_new[soname] = soname_library_map[soname]
+                    changed = True
+                else:
+                    libraries_new[soname] = elf_library
+            if changed:
+                nonpy_elftree[elf_path] = elf_executable.with_libraries(libraries_new)
 
         # Get a list of all external libraries needed by ELFs in the wheel.
         needed_libs = {

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -165,11 +165,11 @@ def get_wheel_elfdata(
             arch = None if architecture is None else architecture.value
             raise NonPlatformWheelError(arch, shared_libraries_with_invalid_machine)
 
-        # auditwheel assumes that if a dependency in a non python ELF tree can be resolved in
-        # any other ELF tree then, it can be loaded from other non python ELF trees as well.
-        # Python extensions ELF trees are not fixed up, they should always be valid in the first
-        # place.
-        # we fix-up nonpy_elftree taking that into account
+        # Auditwheel assumes that if a dependency in a non-Python ELF tree can
+        # be resolved in any other ELF tree, then it can be loaded from other
+        # non-Python ELF trees as well. Python extension ELF trees are not
+        # fixed up; they should always be valid in the first place. We fix up
+        # nonpy_elftree with that assumption in mind.
         soname_library_map: dict[str, DynamicLibrary] = {}
         for elf_executable in itertools.chain(full_elftree.values(), nonpy_elftree.values()):
             for soname, elf_library in elf_executable.libraries.items():

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -173,19 +173,35 @@ def get_wheel_elfdata(
         soname_library_map: dict[str, DynamicLibrary] = {}
         for elf_executable in itertools.chain(full_elftree.values(), nonpy_elftree.values()):
             for soname, elf_library in elf_executable.libraries.items():
-                if elf_library.realpath is not None:
-                    if soname in soname_library_map:
-                        if soname_library_map[soname].realpath != elf_library.realpath:
-                            msg = "inconsistent ELF trees"
-                            raise ValueError(msg)
-                    else:
+                if soname in soname_library_map:
+                    realpath = soname_library_map[soname].realpath
+                    if realpath is None:
                         soname_library_map[soname] = elf_library
+                    elif elf_library.realpath is not None and realpath != elf_library.realpath:
+                        msg = (
+                            f"inconsistent ELF trees: {soname!r} can be resolved as "
+                            f"{realpath!r} or {elf_library.realpath!r}"
+                        )
+                        raise ValueError(msg)
+                else:
+                    soname_library_map[soname] = elf_library
         for elf_path, elf_executable in nonpy_elftree.items():
             libraries_new: dict[str, DynamicLibrary] = {}
+            soname_all = set(elf_executable.libraries.keys())
             changed = False
             for soname, elf_library in elf_executable.libraries.items():
                 if elf_library.realpath is None and soname in soname_library_map:
                     libraries_new[soname] = soname_library_map[soname]
+                    # we need to add newly found dependencies as well
+                    needed_new = set(libraries_new[soname].needed) - soname_all
+                    while needed_new:
+                        needed_new_copy = needed_new.copy()
+                        for soname_needed in needed_new_copy:
+                            if soname_needed not in soname_all:
+                                libraries_new[soname_needed] = soname_library_map[soname_needed]
+                                soname_all.add(soname_needed)
+                                needed_new.update(libraries_new[soname_needed].needed)
+                        needed_new -= soname_all
                     changed = True
                 else:
                     libraries_new[soname] = elf_library

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import functools
 import itertools
 import logging
@@ -183,13 +184,16 @@ def get_wheel_elfdata(
             libraries_new: dict[str, DynamicLibrary] = {}
             changed = False
             for soname, elf_library in elf_executable.libraries.items():
-                if elf_library.path is None and elf_library.soname in soname_library_map:
+                if elf_library.realpath is None and soname in soname_library_map:
                     libraries_new[soname] = soname_library_map[soname]
                     changed = True
                 else:
                     libraries_new[soname] = elf_library
             if changed:
-                nonpy_elftree[elf_path] = elf_executable.with_libraries(libraries_new)
+                nonpy_elftree[elf_path] = dataclasses.replace(
+                    elf_executable,
+                    libraries=libraries_new,
+                )
 
         # Get a list of all external libraries needed by ELFs in the wheel.
         needed_libs = {

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -74,11 +74,11 @@ def _fixup_elf_trees(
     ]
 
     def _get_reference(path_to_elf: Path) -> DynamicExecutable | None:
+        assert path_to_elf.is_file()  # noqa: S101
         for candidate in resolved_executables:
             for library in candidate.libraries.values():
                 assert library.realpath is not None  # noqa: S101
                 assert library.realpath.is_file()  # noqa: S101
-                assert path_to_elf.is_file()  # noqa: S101
                 if path_to_elf.samefile(library.realpath):
                     return candidate
         return None

--- a/src/auditwheel/wheel_abi.py
+++ b/src/auditwheel/wheel_abi.py
@@ -190,7 +190,7 @@ def get_wheel_elfdata(
             soname_all = set(elf_executable.libraries.keys())
             changed = False
             for soname, elf_library in elf_executable.libraries.items():
-                if elf_library.realpath is None and soname in soname_library_map:
+                if elf_library.realpath is None and soname_library_map[soname].realpath is not None:
                     libraries_new[soname] = soname_library_map[soname]
                     # we need to add newly found dependencies as well
                     needed_new = set(libraries_new[soname].needed) - soname_all

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -775,6 +775,34 @@ class Anylinux:
                         assert len(rpath_tags) == 1
                         assert rpath_tags[0].rpath == "$ORIGIN"
 
+    def test_partialresolution(self, anylinux: AnyLinuxContainer, python: PythonContainer) -> None:
+
+        policy = anylinux.policy
+
+        test_path = "/auditwheel_src/tests/integration/testpartialresolution"
+        orig_wheel = anylinux.build_wheel(test_path)
+
+        # Repair the wheel using the appropriate manylinux container
+        anylinux.repair(orig_wheel)
+        repaired_wheel = anylinux.check_wheel("foo")
+        assert_show_output(anylinux, repaired_wheel, policy, False)
+
+        python.install_wheel(repaired_wheel)
+        output = python.run("from foo import foo; print(foo.func())")
+        assert output.strip() == "11"
+
+        with zipfile.ZipFile(anylinux.io_folder / repaired_wheel) as w:
+            libraries = tuple(name for name in w.namelist() if "foo/lib" in name)
+            assert len(libraries) == 2
+            for name in libraries:
+                with w.open(name) as f:
+                    elf = ELFFile(io.BytesIO(f.read()))
+                    dynamic = elf.get_section_by_name(".dynamic")
+                    runpath_tags = [t for t in dynamic.iter_tags() if t.entry.d_tag == "DT_RUNPATH"]
+                    assert len(runpath_tags) == 0
+                    rpath_tags = [t for t in dynamic.iter_tags() if t.entry.d_tag == "DT_RPATH"]
+                    assert len(rpath_tags) == 0
+
     def test_multiple_top_level(
         self,
         anylinux: AnyLinuxContainer,

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -784,15 +784,18 @@ class Anylinux:
 
         # Repair the wheel using the appropriate manylinux container
         anylinux.repair(orig_wheel)
-        repaired_wheel = anylinux.check_wheel("foo")
+        repaired_wheel = anylinux.check_wheel("testpartialresolution")
         assert_show_output(anylinux, repaired_wheel, policy, False)
 
         python.install_wheel(repaired_wheel)
-        output = python.run("from foo import foo; print(foo.func())")
+        output = python.run(
+            "from testpartialresolution import testpartialresolution;"
+            "print(testpartialresolution.func())",
+        )
         assert output.strip() == "11"
 
         with zipfile.ZipFile(anylinux.io_folder / repaired_wheel) as w:
-            libraries = tuple(name for name in w.namelist() if "foo/lib" in name)
+            libraries = tuple(name for name in w.namelist() if "testpartialresolution/lib" in name)
             assert len(libraries) == 2
             for name in libraries:
                 with w.open(name) as f:

--- a/tests/integration/testpartialresolution/MANIFEST.in
+++ b/tests/integration/testpartialresolution/MANIFEST.in
@@ -1,0 +1,2 @@
+graft a
+graft b

--- a/tests/integration/testpartialresolution/a/a.c
+++ b/tests/integration/testpartialresolution/a/a.c
@@ -1,0 +1,6 @@
+#include "b.h"
+
+
+int fa(void) {
+    return 1 + fb();
+}

--- a/tests/integration/testpartialresolution/a/a.h
+++ b/tests/integration/testpartialresolution/a/a.h
@@ -1,0 +1,1 @@
+int fa(void);

--- a/tests/integration/testpartialresolution/b/b.c
+++ b/tests/integration/testpartialresolution/b/b.c
@@ -1,0 +1,3 @@
+int fb(void) {
+    return 10;
+}

--- a/tests/integration/testpartialresolution/b/b.h
+++ b/tests/integration/testpartialresolution/b/b.h
@@ -1,0 +1,1 @@
+int fb(void);

--- a/tests/integration/testpartialresolution/pyproject.toml
+++ b/tests/integration/testpartialresolution/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/tests/integration/testpartialresolution/setup.py
+++ b/tests/integration/testpartialresolution/setup.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
+
+HERE = Path(__file__).parent.resolve(strict=True)
+
+
+class BuildExt(build_ext):
+    def run(self) -> None:
+        outputs = self.get_outputs()
+        assert len(outputs) == 1
+        liba_path = Path(outputs[0]).parent / "liba.so"
+        libb_path = Path(outputs[0]).parent / "libb.so"
+
+        cmd = f"gcc -fPIC -shared -o {libb_path} b/b.c"
+        subprocess.check_call(cmd.split())
+        libb_parent_path = libb_path.parent.resolve(strict=True)
+        cmd = f"gcc -fPIC -shared -o {liba_path} -Ib a/a.c -L{libb_parent_path} -lb"
+        subprocess.check_call(cmd.split())
+        liba_path = liba_path.resolve(strict=True)
+        liba_link_path = Path("a/liba.so")
+        if liba_link_path.exists():
+            liba_link_path.unlink()
+        liba_link_path.symlink_to(liba_path)
+
+        super().run()
+
+
+setup(
+    name="foo",
+    version="0.0.1",
+    packages=["foo"],
+    package_dir={"": "src"},
+    cmdclass={"build_ext": BuildExt},
+    ext_modules=[
+        Extension(
+            "foo/foo",
+            sources=["src/foo/foo.c"],
+            extra_link_args=["-Wl,--disable-new-dtags", "-Wl,-rpath=$ORIGIN"],
+            include_dirs=["a"],
+            libraries=["a"],
+            library_dirs=["a"],
+        ),
+    ],
+)

--- a/tests/integration/testpartialresolution/setup.py
+++ b/tests/integration/testpartialresolution/setup.py
@@ -29,15 +29,15 @@ class BuildExt(build_ext):
 
 
 setup(
-    name="foo",
+    name="testpartialresolution",
     version="0.0.1",
-    packages=["foo"],
+    packages=["testpartialresolution"],
     package_dir={"": "src"},
     cmdclass={"build_ext": BuildExt},
     ext_modules=[
         Extension(
-            "foo/foo",
-            sources=["src/foo/foo.c"],
+            "testpartialresolution/testpartialresolution",
+            sources=["src/testpartialresolution/testpartialresolution.c"],
             extra_link_args=["-Wl,--disable-new-dtags", "-Wl,-rpath=$ORIGIN"],
             include_dirs=["a"],
             libraries=["a"],

--- a/tests/integration/testpartialresolution/setup.py
+++ b/tests/integration/testpartialresolution/setup.py
@@ -6,8 +6,6 @@ from pathlib import Path
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-HERE = Path(__file__).parent.resolve(strict=True)
-
 
 class BuildExt(build_ext):
     def run(self) -> None:

--- a/tests/integration/testpartialresolution/src/foo/foo.c
+++ b/tests/integration/testpartialresolution/src/foo/foo.c
@@ -22,8 +22,8 @@ PyMODINIT_FUNC PyInit_foo(void)
     };
     static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
-        "testrpath",
-        "testrpath module",
+        "foo",
+        "foo module",
         -1,
         module_methods,
     };

--- a/tests/integration/testpartialresolution/src/foo/foo.c
+++ b/tests/integration/testpartialresolution/src/foo/foo.c
@@ -1,0 +1,31 @@
+#include <Python.h>
+#include "a.h"
+
+static PyObject *
+func(PyObject *self, PyObject *args)
+{
+    int res;
+
+    (void)self;
+    (void)args;
+
+    res = fa();
+    return PyLong_FromLong(res);
+}
+
+/* Module initialization */
+PyMODINIT_FUNC PyInit_foo(void)
+{
+    static PyMethodDef module_methods[] = {
+        {"func", (PyCFunction)func, METH_NOARGS, "func."},
+        {NULL}  /* Sentinel */
+    };
+    static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "testrpath",
+        "testrpath module",
+        -1,
+        module_methods,
+    };
+    return PyModule_Create(&moduledef);
+}

--- a/tests/integration/testpartialresolution/src/testpartialresolution/testpartialresolution.c
+++ b/tests/integration/testpartialresolution/src/testpartialresolution/testpartialresolution.c
@@ -14,7 +14,7 @@ func(PyObject *self, PyObject *args)
 }
 
 /* Module initialization */
-PyMODINIT_FUNC PyInit_foo(void)
+PyMODINIT_FUNC PyInit_testpartialresolution(void)
 {
     static PyMethodDef module_methods[] = {
         {"func", (PyCFunction)func, METH_NOARGS, "func."},
@@ -22,8 +22,8 @@ PyMODINIT_FUNC PyInit_foo(void)
     };
     static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
-        "foo",
-        "foo module",
+        "testpartialresolution",
+        "testpartialresolution module",
         -1,
         module_methods,
     };

--- a/tests/unit/test_wheel_abi.py
+++ b/tests/unit/test_wheel_abi.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from pathlib import Path
 
@@ -99,8 +100,9 @@ def test_get_symbol_policies() -> None:
     assert max_policy.name == "manylinux_2_17_x86_64"
 
 
-@pytest.mark.parametrize("resolved", [True, False])
-def test_nonpy_elf_resolution(tmp_path: Path, resolved) -> None:
+@pytest.mark.parametrize("kind", ["resolved", "unresolved", "warning"])
+def test_nonpy_elf_resolution(kind: bool, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.WARNING)
     liba_path = tmp_path / "liba.so"
     libb_path = tmp_path / "libb.so"
     liba_path.touch()
@@ -133,7 +135,7 @@ def test_nonpy_elf_resolution(tmp_path: Path, resolved) -> None:
     libraries = {
         "liba.so": DynamicLibrary("liba.so", liba.path, liba.realpath, liba.platform, liba.needed),
     }
-    if resolved:
+    if kind == "resolved":
         libraries["libb.so"] = DynamicLibrary(
             "libb.so",
             libb.path,
@@ -141,6 +143,8 @@ def test_nonpy_elf_resolution(tmp_path: Path, resolved) -> None:
             libb.platform,
             libb.needed,
         )
+    elif kind == "unresolved":
+        libraries["libb.so"] = DynamicLibrary("libb.so", None, None)
     extension = DynamicExecutable(
         interpreter=None,
         libc=None,
@@ -156,7 +160,109 @@ def test_nonpy_elf_resolution(tmp_path: Path, resolved) -> None:
     nonpy_elftrees = {liba.realpath: liba, libb.realpath: libb}
     wheel_abi._fixup_elf_trees(pyelf_trees, nonpy_elftrees)
     assert pyelf_trees == {extension.realpath: extension}
-    if resolved:
+    if kind == "resolved":
         assert nonpy_elftrees != {liba.realpath: liba, libb.realpath: libb}
     else:
         assert nonpy_elftrees == {liba.realpath: liba, libb.realpath: libb}
+    if kind == "warning":
+        assert len(caplog.records) == 1
+    else:
+        assert len(caplog.records) == 0
+
+
+@pytest.mark.parametrize("kind", ["resolved", "unresolved", "warning"])
+def test_nonpy_elf_resolution_transitive_needed(
+    kind: bool,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING)
+    liba_path = tmp_path / "liba.so"
+    libb_path = tmp_path / "libb.so"
+    libc_path = tmp_path / "libc.so"
+    liba_path.touch()
+    libb_path.touch()
+    libc_path.touch()
+    platform = Platform("", 64, True, "EM_X86_64", Architecture.x86_64, None, None)
+    libc = DynamicExecutable(
+        interpreter=None,
+        libc=None,
+        path="libc.so",
+        realpath=libc_path,
+        platform=platform,
+        needed=(),
+        rpath=(),
+        runpath=(),
+        libraries={},
+    )
+    libb = DynamicExecutable(
+        interpreter=None,
+        libc=None,
+        path="libb.so",
+        realpath=libb_path,
+        platform=platform,
+        needed=("libc.so",),
+        rpath=(),
+        runpath=(),
+        libraries={
+            "libc.so": DynamicLibrary("libc.so", None, None),
+        },
+    )
+    liba = DynamicExecutable(
+        interpreter=None,
+        libc=None,
+        path="liba.so",
+        realpath=liba_path,
+        platform=platform,
+        needed=("libb.so",),
+        rpath=(),
+        runpath=(),
+        libraries={
+            "libb.so": DynamicLibrary("libb.so", None, None),
+        },
+    )
+    libraries = {
+        "liba.so": DynamicLibrary("liba.so", liba.path, liba.realpath, liba.platform, liba.needed),
+    }
+    if kind in {"resolved", "warning"}:
+        libraries["libb.so"] = DynamicLibrary(
+            "libb.so",
+            libb.path,
+            libb.realpath,
+            libb.platform,
+            libb.needed,
+        )
+        if kind == "resolved":
+            libraries["libc.so"] = DynamicLibrary(
+                "libc.so",
+                libc.path,
+                libc.realpath,
+                libc.platform,
+                libc.needed,
+            )
+    elif kind == "unresolved":
+        libraries["libb.so"] = DynamicLibrary("libb.so", None, None)
+
+    extension = DynamicExecutable(
+        interpreter=None,
+        libc=None,
+        path="extension.so",
+        realpath=Path("extension.so"),
+        platform=platform,
+        needed=("liba.so",),
+        rpath=(),
+        runpath=(),
+        libraries=libraries,
+    )
+    pyelf_trees = {extension.realpath: extension}
+    nonpy_elftrees = {liba.realpath: liba, libb.realpath: libb, libc.realpath: libc}
+    wheel_abi._fixup_elf_trees(pyelf_trees, nonpy_elftrees)
+    assert pyelf_trees == {extension.realpath: extension}
+    if kind in {"resolved", "warning"}:
+        assert nonpy_elftrees != {liba.realpath: liba, libb.realpath: libb, libc.realpath: libc}
+    else:
+        assert nonpy_elftrees == {liba.realpath: liba, libb.realpath: libb, libc.realpath: libc}
+    if kind == "warning":
+        assert len(caplog.records) == 2
+    else:
+        assert len(caplog.records) == 0

--- a/tests/unit/test_wheel_abi.py
+++ b/tests/unit/test_wheel_abi.py
@@ -162,8 +162,10 @@ def test_nonpy_elf_resolution(kind: str, tmp_path: Path, caplog: pytest.LogCaptu
     assert pyelf_trees == {extension.realpath: extension}
     if kind == "resolved":
         assert nonpy_elftrees != {liba.realpath: liba, libb.realpath: libb}
+        assert nonpy_elftrees[liba.realpath].libraries["libb.so"].realpath == libb.realpath
     else:
         assert nonpy_elftrees == {liba.realpath: liba, libb.realpath: libb}
+        assert nonpy_elftrees[liba.realpath].libraries["libb.so"].realpath is None
     if kind == "warning":
         assert len(caplog.records) == 1
     else:
@@ -260,8 +262,18 @@ def test_nonpy_elf_resolution_transitive_needed(
     assert pyelf_trees == {extension.realpath: extension}
     if kind in {"resolved", "warning"}:
         assert nonpy_elftrees != {liba.realpath: liba, libb.realpath: libb, libc.realpath: libc}
+        assert nonpy_elftrees[liba.realpath].libraries["libb.so"].realpath ==  libb.realpath
+        if kind == "resolved":
+            assert nonpy_elftrees[liba.realpath].libraries["libc.so"].realpath == libc.realpath
+            assert nonpy_elftrees[libb.realpath].libraries["libc.so"].realpath == libc.realpath
+        else:
+            assert "libc.so" not in nonpy_elftrees[liba.realpath].libraries
+            assert nonpy_elftrees[libb.realpath].libraries["libc.so"].realpath is None
     else:
         assert nonpy_elftrees == {liba.realpath: liba, libb.realpath: libb, libc.realpath: libc}
+        assert nonpy_elftrees[liba.realpath].libraries["libb.so"].realpath is None
+        assert "libc.so" not in nonpy_elftrees[liba.realpath].libraries
+        assert nonpy_elftrees[libb.realpath].libraries["libc.so"].realpath is None
     if kind == "warning":
         assert len(caplog.records) == 2
     else:

--- a/tests/unit/test_wheel_abi.py
+++ b/tests/unit/test_wheel_abi.py
@@ -8,6 +8,7 @@ import pytest
 
 from auditwheel import wheel_abi
 from auditwheel.architecture import Architecture
+from auditwheel.lddtree import DynamicExecutable, DynamicLibrary, Platform
 from auditwheel.libc import Libc
 from auditwheel.policy import ExternalReference, WheelPolicies
 
@@ -96,3 +97,66 @@ def test_get_symbol_policies() -> None:
     )
     max_policy = max(symbol_policy[0] for symbol_policy in symbol_policies)
     assert max_policy.name == "manylinux_2_17_x86_64"
+
+
+@pytest.mark.parametrize("resolved", [True, False])
+def test_nonpy_elf_resolution(tmp_path: Path, resolved) -> None:
+    liba_path = tmp_path / "liba.so"
+    libb_path = tmp_path / "libb.so"
+    liba_path.touch()
+    libb_path.touch()
+    platform = Platform("", 64, True, "EM_X86_64", Architecture.x86_64, None, None)
+    libb = DynamicExecutable(
+        interpreter=None,
+        libc=None,
+        path="libb.so",
+        realpath=libb_path,
+        platform=platform,
+        needed=(),
+        rpath=(),
+        runpath=(),
+        libraries={},
+    )
+    liba = DynamicExecutable(
+        interpreter=None,
+        libc=None,
+        path="liba.so",
+        realpath=liba_path,
+        platform=platform,
+        needed=("libb.so",),
+        rpath=(),
+        runpath=(),
+        libraries={
+            "libb.so": DynamicLibrary("libb.so", None, None),
+        },
+    )
+    libraries = {
+        "liba.so": DynamicLibrary("liba.so", liba.path, liba.realpath, liba.platform, liba.needed),
+    }
+    if resolved:
+        libraries["libb.so"] = DynamicLibrary(
+            "libb.so",
+            libb.path,
+            libb.realpath,
+            libb.platform,
+            libb.needed,
+        )
+    extension = DynamicExecutable(
+        interpreter=None,
+        libc=None,
+        path="extension.so",
+        realpath=Path("extension.so"),
+        platform=platform,
+        needed=("liba.so",),
+        rpath=(),
+        runpath=(),
+        libraries=libraries,
+    )
+    pyelf_trees = {extension.realpath: extension}
+    nonpy_elftrees = {liba.realpath: liba, libb.realpath: libb}
+    wheel_abi._fixup_elf_trees(pyelf_trees, nonpy_elftrees)
+    assert pyelf_trees == {extension.realpath: extension}
+    if resolved:
+        assert nonpy_elftrees != {liba.realpath: liba, libb.realpath: libb}
+    else:
+        assert nonpy_elftrees == {liba.realpath: liba, libb.realpath: libb}

--- a/tests/unit/test_wheel_abi.py
+++ b/tests/unit/test_wheel_abi.py
@@ -101,7 +101,7 @@ def test_get_symbol_policies() -> None:
 
 
 @pytest.mark.parametrize("kind", ["resolved", "unresolved", "warning"])
-def test_nonpy_elf_resolution(kind: bool, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+def test_nonpy_elf_resolution(kind: str, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.WARNING)
     liba_path = tmp_path / "liba.so"
     libb_path = tmp_path / "libb.so"
@@ -172,7 +172,7 @@ def test_nonpy_elf_resolution(kind: bool, tmp_path: Path, caplog: pytest.LogCapt
 
 @pytest.mark.parametrize("kind", ["resolved", "unresolved", "warning"])
 def test_nonpy_elf_resolution_transitive_needed(
-    kind: bool,
+    kind: str,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/unit/test_wheel_abi.py
+++ b/tests/unit/test_wheel_abi.py
@@ -166,10 +166,15 @@ def test_nonpy_elf_resolution(kind: str, tmp_path: Path, caplog: pytest.LogCaptu
     else:
         assert nonpy_elftrees == {liba.realpath: liba, libb.realpath: libb}
         assert nonpy_elftrees[liba.realpath].libraries["libb.so"].realpath is None
+    warnings = [
+        record
+        for record in caplog.records
+        if "ELF tree" in record.message and record.levelno == logging.WARNING
+    ]
     if kind == "warning":
-        assert len(caplog.records) == 1
+        assert len(warnings) == 1
     else:
-        assert len(caplog.records) == 0
+        assert len(warnings) == 0
 
 
 @pytest.mark.parametrize("kind", ["resolved", "unresolved", "warning"])
@@ -274,7 +279,13 @@ def test_nonpy_elf_resolution_transitive_needed(
         assert nonpy_elftrees[liba.realpath].libraries["libb.so"].realpath is None
         assert "libc.so" not in nonpy_elftrees[liba.realpath].libraries
         assert nonpy_elftrees[libb.realpath].libraries["libc.so"].realpath is None
+
+    warnings = [
+        record
+        for record in caplog.records
+        if "ELF tree" in record.message and record.levelno == logging.WARNING
+    ]
     if kind == "warning":
-        assert len(caplog.records) == 2
+        assert len(warnings) == 2
     else:
-        assert len(caplog.records) == 0
+        assert len(warnings) == 0

--- a/tests/unit/test_wheel_abi.py
+++ b/tests/unit/test_wheel_abi.py
@@ -262,7 +262,7 @@ def test_nonpy_elf_resolution_transitive_needed(
     assert pyelf_trees == {extension.realpath: extension}
     if kind in {"resolved", "warning"}:
         assert nonpy_elftrees != {liba.realpath: liba, libb.realpath: libb, libc.realpath: libc}
-        assert nonpy_elftrees[liba.realpath].libraries["libb.so"].realpath ==  libb.realpath
+        assert nonpy_elftrees[liba.realpath].libraries["libb.so"].realpath == libb.realpath
         if kind == "resolved":
             assert nonpy_elftrees[liba.realpath].libraries["libc.so"].realpath == libc.realpath
             assert nonpy_elftrees[libb.realpath].libraries["libc.so"].realpath == libc.realpath


### PR DESCRIPTION
auditwheel should assumes that if a dependency in a non python ELF tree can be resolved in any other fully resolved  ELF tree then, it can be loaded from other non python ELF trees as well.

Python extensions ELF trees should be not fixed up, they should always be valid in the first place.

The rationale for this difference between Python extensions ELF trees and non python ELF trees is that we know that python extensions ELF are "top-level" and should be able to load all their dependencies. We can't assume non python ELF files are "top-level" and thus fix-up resolution using other ELF trees if we can.

Missing tests for now

close #683
fix #531
