### PR TITLE
fix: don't conflate ZLIB_NG_* with ZLIB_* in symbol-version policy check

### DIFF
--- a/src/auditwheel/policy/__init__.py
+++ b/src/auditwheel/policy/__init__.py
@@ -21,6 +21,13 @@ if TYPE_CHECKING:
 
 _HERE = Path(__file__).parent
 _MUSL_POLICY_RE = re.compile(r"^musllinux_\d+_\d+$")
+# Match a versioned-symbol tag like "GLIBC_2.17", "ZLIB_NG_2.0.0",
+# "CXXABI_LDBL_1.3" or "OPENSSL_1_1_0" and capture the namespace
+# (everything before the trailing "_<numeric version>"). The version
+# tail is required to be numeric (with `.` or `_` separators) so
+# tags whose suffix is a word like "GLIBC_PRIVATE" don't match;
+# those fall back to the legacy partition-on-first-underscore split.
+_SYMBOL_VERSION_TAG_RE = re.compile(r"^([A-Za-z][A-Za-z0-9_]*?)_(\d+(?:[._]\d+)*)$")
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +183,16 @@ class WheelPolicies:
         required_vers: dict[str, set[str]] = {}
         for symbols in versioned_symbols.values():
             for symbol in symbols:
-                sym_name, _, _ = symbol.partition("_")
+                # Bucket the tag by namespace. Tags with a trailing
+                # numeric version (the common case) use the regex so
+                # multi-underscore namespaces like ZLIB_NG, CXXABI_LDBL,
+                # or LIBSSL_1_1 stay distinct from ZLIB / CXXABI / LIBSSL
+                # rather than being merged with them. Tags without a
+                # numeric tail (e.g. "GLIBC_PRIVATE", or fully bare
+                # tokens with no underscore) fall back to splitting on
+                # the first underscore so existing behavior is kept.
+                m = _SYMBOL_VERSION_TAG_RE.match(symbol)
+                sym_name = m.group(1) if m else symbol.partition("_")[0]
                 required_vers.setdefault(sym_name, set()).add(symbol)
         for p in self._policies[::-1]:
             policy_sym_vers = {

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -266,3 +266,30 @@ def test_policy_checks_glibc():
     policy = policies.versioned_symbols_policy({"some_library.so": {"IAMALIBRARY"}})
     assert policy == policies.highest
     assert policies.linux < policies.lowest < policies.highest
+
+
+def test_policy_does_not_conflate_zlib_ng_with_zlib():
+    # Regression for https://github.com/pypa/auditwheel/issues/613.
+    # zlib-ng tags every exported symbol with ZLIB_NG_2.0.0 / ZLIB_NG_2.1.0
+    # via its GNU symbol version script. Splitting these tags on the first
+    # underscore put them in the "ZLIB" namespace and made them fail every
+    # policy whose ZLIB allowlist did not contain ZLIB_NG_*. The bucketing
+    # must keep ZLIB_NG distinct from ZLIB so the (unmodelled) ZLIB_NG
+    # namespace is silently dropped from the policy check, the same way
+    # any other unrecognised namespace already is.
+    policies = WheelPolicies(libc=Libc.GLIBC, arch=Architecture.x86_64)
+
+    policy = policies.versioned_symbols_policy(
+        {"libz-ng.so.2": {"ZLIB_NG_2.0.0", "ZLIB_NG_2.1.0"}},
+    )
+    assert policy == policies.highest
+
+    # And mixing libz-ng tags with stock-zlib tags must not poison the
+    # ZLIB bucket -- the ZLIB_1.2.0 check still needs to pass on its own.
+    policy = policies.versioned_symbols_policy(
+        {
+            "libz.so.1": {"ZLIB_1.2.0"},
+            "libz-ng.so.2": {"ZLIB_NG_2.0.0"},
+        },
+    )
+    assert policy > policies.linux


### PR DESCRIPTION
Fixes #613.

## Why

`versioned_symbols_policy` buckets every version tag by splitting on the *first* underscore:

```python
sym_name, _, _ = symbol.partition("_")
required_vers.setdefault(sym_name, set()).add(symbol)
```

For zlib-ng's `ZLIB_NG_2.0.0` / `ZLIB_NG_2.1.0` tags this produces namespace `ZLIB`, landing them in the same bucket as stock zlib's `ZLIB_1.2.0`. Policies whose `ZLIB` allowlist does not contain `ZLIB_NG_*` (none do — libz-ng.so.2 is not a manylinux system library) then reject the wheel as carrying *"too-recent versioned symbols"*, even though no symbol is actually too recent. This is exactly what #613 reports, and matches @mayeut's diagnosis on that issue:

> it's not intended, needs a fix to exclude `ZLIB_NG_*`.

The same class of bug also bites `CXXABI_LDBL_*.*` (long-double-specific libstdc++ symbols), which currently get bucketed into `CXXABI` and collide with `CXXABI_*.*`.

## What

Match the namespace with a regex that requires a trailing numeric version (`\d+(?:[._]\d+)*`):

```python
_SYMBOL_VERSION_TAG_RE = re.compile(r"^([A-Za-z][A-Za-z0-9_]*?)_(\d+(?:[._]\d+)*)$")
```

Now `ZLIB_NG_2.0.0` resolves to namespace `ZLIB_NG` instead of `ZLIB`, and `CXXABI_LDBL_1.3` resolves to `CXXABI_LDBL` instead of `CXXABI`. Tags whose suffix is not a numeric version (e.g. `GLIBC_PRIVATE`, or fully bare tokens with no `_`) fall back to the original first-underscore split so existing behavior is preserved.

Because `ZLIB_NG` and `CXXABI_LDBL` don't appear in any policy's `symbol_versions` map, the existing `set(required_vers) & set(policy_sym_vers)` intersection in `policy_is_satisfied` then drops them from the check entirely — the same way any other unmodelled namespace (e.g. `OPENSSL`, `LIBSSL`) already is — and the wheel passes.

## Test

Added `test_policy_does_not_conflate_zlib_ng_with_zlib` covering:
- A wheel with only `ZLIB_NG_*` tags is accepted (was rejected before).
- A wheel mixing `ZLIB_1.2.0` and `ZLIB_NG_2.0.0` doesn't poison the `ZLIB` bucket — the `ZLIB_1.2.0` check still has to pass on its own.

The new test plus all existing `test_policy.py` tests pass:

```
============================= 19 passed in 0.15s ==============================
```

(The remaining unit-test failures on Windows are pre-existing environmental issues — symlink privilege, Linux-only ctypes for `test_libc.py`, Unix permission modes in `test_tools.py` — and are unrelated to this change.)
