### PR TITLE
feat: add Python 3.15 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       matrix:
         platform:
           - [ 'x86_64', 'ubuntu-24.04' ]
-        python: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python: [ '3.10', '3.11', '3.12', '3.13', '3.14', '3.15' ]
         include:
           - platform: [ 'aarch64', 'ubuntu-24.04-arm' ]
             python: '3.12'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   test-dist:
@@ -40,13 +40,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Install CPython 3.10
+      - name: Install CPython 3.11
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           architecture: x64
       - name: Run tests
-        run: pipx run nox -s test-sdist-3.10 test-wheel-3.10
+        run: pipx run nox -s test-sdist-3.11 test-wheel-3.11
 
   test:
     name: CPython ${{ matrix.python }} ${{ matrix.platform[0] }} on ${{ matrix.platform[1] }}
@@ -59,7 +59,7 @@ jobs:
       matrix:
         platform:
           - [ 'x86_64', 'ubuntu-24.04' ]
-        python: [ '3.10', '3.11', '3.12', '3.13', '3.14', '3.15' ]
+        python: [ '3.11', '3.12', '3.13', '3.14', '3.15' ]
         include:
           - platform: [ 'aarch64', 'ubuntu-24.04-arm' ]
             python: '3.12'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,6 @@ repos:
   hooks:
   - id: mypy
     exclude: tests/integration/.*/.*|tests/integration/quick_check_numpy.py|tests/unit/test_wheel_abi.py|scripts/calculate_symbol_versions.py
-    args: ["--python-version=3.10"]
     additional_dependencies:
       - nox
       - packaging

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ advised that bundling, like static linking, may implicate copyright concerns.
 Requirements
 ------------
 - OS: Linux (for Android wheels, macOS may also be used)
-- Python: 3.10+
+- Python: 3.11+
 - `patchelf <https://github.com/NixOS/patchelf>`_: 0.14.5+
 
 Only systems that use `ELF
@@ -130,9 +130,9 @@ test dependencies.
 Some of the integration tests also require a running and accessible Docker
 daemon. These tests will pull a number of docker images if they are not already
 available on your system, but it won't update existing images.
-To update these images manually, run::
+To update these images manually, run:
 
-    docker pull python:3.10-slim-trixie
+    docker pull python:3.11-slim-trixie
     docker pull quay.io/pypa/manylinux2010_x86_64
     docker pull quay.io/pypa/manylinux2014_x86_64
     docker pull quay.io/pypa/manylinux_2_28_x86_64

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,7 @@ import nox
 
 nox.needs_version = ">=2025.2.9"
 
-PYTHON_ALL_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
+PYTHON_ALL_VERSIONS = ["3.11", "3.12", "3.13", "3.14", "3.15"]
 RUNNING_CI = "TRAVIS" in os.environ or "GITHUB_ACTIONS" in os.environ
 
 wheel = ""
@@ -108,7 +108,7 @@ def tests(session: nox.Session) -> None:
         session.run("coverage", "xml", f"-ocoverage-{suffix}.xml")
 
 
-@nox.session(python=["3.10"], default=False)
+@nox.session(python=["3.11"], default=False)
 def build(session: nox.Session) -> None:
     session.install("build")
     tmp_dir = Path(session.create_tmp()) / "build-output"

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,7 @@ import nox
 
 nox.needs_version = ">=2025.2.9"
 
-PYTHON_ALL_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14"]
+PYTHON_ALL_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
 RUNNING_CI = "TRAVIS" in os.environ or "GITHUB_ACTIONS" in os.environ
 
 wheel = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Cross-distribution Linux wheels"
 readme = "README.rst"
 license = {text = "MIT" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "Robert T. McGibbon", email = "rmcgibbo@gmail.com" },
 ]
@@ -19,7 +19,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -80,6 +79,7 @@ exclude_also = [
 ]
 
 [tool.mypy]
+python_version = "3.11"
 check_untyped_defs = true
 disallow_any_generics = true
 disallow_incomplete_defs = true
@@ -112,7 +112,7 @@ log_cli = true
 log_cli_level = 20
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 line-length = 100
 lint.select = ["ALL"]
 lint.ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: Build Tools",

--- a/src/auditwheel/tools.py
+++ b/src/auditwheel/tools.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import time
 import zipfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -150,7 +150,7 @@ def dir2zip(
     in_dir = in_dir.resolve(strict=True)
     if date_time is None:
         st = in_dir.stat()
-        date_time = datetime.fromtimestamp(st.st_mtime, tz=timezone.utc)
+        date_time = datetime.fromtimestamp(st.st_mtime, tz=UTC)
     date_time_args = date_time.timetuple()[:6]
     if date_time_args < (1980, 1, 1, 0, 0, 0):
         logger.warning("dir2zip, clipping timestamp to 1980-01-01")

--- a/src/auditwheel/wheeltools.py
+++ b/src/auditwheel/wheeltools.py
@@ -12,7 +12,7 @@ import os
 import re
 import zlib
 from base64 import urlsafe_b64encode
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from itertools import product
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -142,7 +142,7 @@ class InWheel(InTemporaryDirectory):
             date_time = None
             timestamp = os.environ.get("SOURCE_DATE_EPOCH")
             if timestamp:
-                date_time = datetime.fromtimestamp(int(timestamp), tz=timezone.utc)
+                date_time = datetime.fromtimestamp(int(timestamp), tz=UTC)
             dir2zip(self.name, self.out_wheel, self.zip_compression_level, date_time)
         return super().__exit__(exc, value, tb)
 

--- a/tests/integration/test_bundled_wheels.py
+++ b/tests/integration/test_bundled_wheels.py
@@ -5,7 +5,7 @@ import os
 import sys
 import zipfile
 from argparse import Namespace
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock
@@ -214,7 +214,7 @@ def test_wheel_source_date_epoch(timestamp, tmp_path, monkeypatch):
     output_wheel, *_ = list(wheel_output_path.glob("*.whl"))
     with zipfile.ZipFile(output_wheel) as wheel_file:
         for file in wheel_file.infolist():
-            file_date_time = datetime(*file.date_time, tzinfo=timezone.utc)
+            file_date_time = datetime(*file.date_time, tzinfo=UTC)
             assert file_date_time.timestamp() == timestamp[1]
 
 

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -78,7 +78,7 @@ DOCKER_CONTAINER_NAME = "auditwheel-test-anylinux"
 PYTHON_MAJ_MIN = [str(i) for i in sys.version_info[:2]]
 PYTHON_ABI_MAJ_MIN = "".join(PYTHON_MAJ_MIN)
 PYTHON_ABI = f"cp{PYTHON_ABI_MAJ_MIN}-cp{PYTHON_ABI_MAJ_MIN}"
-PYTHON_IMAGE_TAG = ".".join(PYTHON_MAJ_MIN) + ("-rc" if PYTHON_ABI_MAJ_MIN == "314" else "")
+PYTHON_IMAGE_TAG = ".".join(PYTHON_MAJ_MIN) + ("-rc" if PYTHON_ABI_MAJ_MIN == "315" else "")
 MANYLINUX_PYTHON_IMAGE_ID = f"python:{PYTHON_IMAGE_TAG}-slim-trixie"
 MUSLLINUX_IMAGES = {
     "musllinux_1_2": f"quay.io/pypa/musllinux_1_2_{PLATFORM}:latest",
@@ -113,6 +113,7 @@ NUMPY_VERSION_MAP = {
     "312": "1.26.4",
     "313": "2.0.1",
     "314": "2.3.2",
+    "315": "2.5.1",
 }
 NUMPY_VERSION = NUMPY_VERSION_MAP[PYTHON_ABI_MAJ_MIN]
 ORIGINAL_NUMPY_WHEEL = f"numpy-{NUMPY_VERSION}-{PYTHON_ABI}-linux_{PLATFORM}.whl"

--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -34,7 +34,6 @@ if "GITHUB_ACTIONS" in os.environ and sys.platform == "darwin":
     pytest.skip("Docker is not available on GitHub Actions macOS runners", allow_module_level=True)
 
 PLATFORM = os.environ.get("AUDITWHEEL_ARCH", Architecture.detect().value)
-MANYLINUX2010_IMAGE_ID = f"quay.io/pypa/manylinux2010_{PLATFORM}:latest"
 MANYLINUX2014_IMAGE_ID = f"quay.io/pypa/manylinux2014_{PLATFORM}:latest"
 MANYLINUX_2_28_IMAGE_ID = f"quay.io/pypa/manylinux_2_28_{PLATFORM}:latest"
 MANYLINUX_2_31_IMAGE_ID = f"quay.io/pypa/manylinux_2_31_{PLATFORM}:latest"
@@ -43,7 +42,6 @@ MANYLINUX_2_35_IMAGE_ID = f"quay.io/pypa/manylinux_2_35_{PLATFORM}:latest"
 MANYLINUX_2_39_IMAGE_ID = f"quay.io/pypa/manylinux_2_39_{PLATFORM}:latest"
 if PLATFORM in {"i686", "x86_64"}:
     MANYLINUX_IMAGES = {
-        "manylinux_2_12": MANYLINUX2010_IMAGE_ID,
         "manylinux_2_17": MANYLINUX2014_IMAGE_ID,
         "manylinux_2_28": MANYLINUX_2_28_IMAGE_ID,
         "manylinux_2_34": MANYLINUX_2_34_IMAGE_ID,
@@ -85,7 +83,6 @@ MUSLLINUX_IMAGES = {
 }
 MUSLLINUX_PYTHON_IMAGE_ID = f"python:{PYTHON_IMAGE_TAG}-alpine"
 DEVTOOLSET = {
-    "manylinux_2_12": "devtoolset-8",
     "manylinux_2_17": "devtoolset-10",
     "manylinux_2_28": "gcc-toolset-14",
     "manylinux_2_31": "devtoolset-not-present",
@@ -108,7 +105,6 @@ PATH = {k: ":".join(PATH_DIRS).format(devtoolset=v) for k, v in DEVTOOLSET.items
 WHEEL_CACHE_FOLDER = Path.home().joinpath(".cache", "auditwheel_tests")
 HERE = Path(__file__).parent.resolve(strict=True)
 NUMPY_VERSION_MAP = {
-    "310": "1.21.4",
     "311": "1.23.4",
     "312": "1.26.4",
     "313": "2.0.1",
@@ -451,7 +447,7 @@ def build_numpy(container: AnyLinuxContainer, output_dir: Path) -> str:
             # https://github.com/numpy/numpy/issues/27932
             fix_hwcap = "echo '#define HWCAP_S390_VX 2048' >> /usr/include/bits/hwcap.h"
             container.exec(f'sh -c "{fix_hwcap}"')
-    elif container.policy.startswith(("manylinux_2_12_", "manylinux_2_17_")):
+    elif container.policy.startswith("manylinux_2_17_"):
         if tuple(int(part) for part in NUMPY_VERSION.split(".")[:2]) >= (1, 26):
             pytest.skip("numpy>=1.26 requires openblas")
         container.exec("yum install -y atlas atlas-devel")
@@ -619,8 +615,6 @@ class Anylinux:
         python: PythonContainer,
     ) -> None:
         policy = anylinux.policy
-        if policy.startswith("manylinux_2_12_"):
-            pytest.skip(f"whichprovides doesn't support {policy}")
 
         # Build and repair numpy
         orig_wheel = build_numpy(anylinux, anylinux.io_folder)
@@ -1016,7 +1010,7 @@ class Anylinux:
     @pytest.mark.parametrize("isa_ext", ["x86-64-v2", "x86-64-v3", "x86-64-v4"])
     def test_isa_variants(self, anylinux: AnyLinuxContainer, isa_ext: str) -> None:
         policy = anylinux.policy
-        if policy.startswith(("manylinux_2_12_", "manylinux_2_17_")):
+        if policy.startswith("manylinux_2_17_"):
             pytest.skip("skip old gcc")
 
         test_path = "/auditwheel_src/tests/integration/testdependencies"
@@ -1101,18 +1095,12 @@ class TestManylinux(Anylinux):
     def any_manylinux_img(self, request):
         """Each manylinux image, with auditwheel installed."""
         policy, patcher = request.param
-        check_set = {
-            "manylinux_2_12": {"38", "39", "310"},
-        }.get(policy)
-        if check_set and PYTHON_ABI_MAJ_MIN not in check_set:
-            pytest.skip(f"{policy} images do not support cp{PYTHON_ABI_MAJ_MIN}")
-
         base = MANYLINUX_IMAGES[policy]
         env = {"PATH": PATH[policy]}
         if patcher != "patchelf":
             env["AUDITWHEEL_PATCHER"] = patcher
         commands = Anylinux.get_auditwheel_install_commands(patcher)
-        if policy in {"manylinux_2_12", "manylinux_2_17"}:
+        if policy == "manylinux_2_17":
             commands.append("yum install -y gsl-devel atlas atlas-devel")
         elif policy in {"manylinux_2_31", "manylinux_2_35"}:
             commands.extend(("apt-get update -yqq", "apt-get install -y libopenblas-dev execstack"))
@@ -1247,7 +1235,7 @@ class TestManylinux(Anylinux):
         # Tests https://github.com/pypa/auditwheel/issues/645
         policy = anylinux.policy
 
-        if policy.startswith(("manylinux_2_12_", "manylinux_2_17_")):
+        if policy.startswith("manylinux_2_17_"):
             pytest.skip(f"libmvec not supported on {policy}")
 
         test_path = "/auditwheel_src/tests/integration/test_mvec"


### PR DESCRIPTION
Support for Python 3.15 will land after its release.
It will be coupled with dropping Python 3.10 which will be EOL at that time (or very close to EOL).
This PR allows to check for things to fix - if any - before that happens.
