### PR TITLE
feat: reduce calls to patchelf

### DIFF
--- a/src/auditwheel/patcher.py
+++ b/src/auditwheel/patcher.py
@@ -110,6 +110,7 @@ def _verify_patchelf() -> Path:
     if m and tuple(int(x) for x in m.group(1).split(".")) >= (0, 14):
         return Path(patchelf_path)
     msg = f"{version.strip()} found. auditwheel repair requires patchelf >= 0.14."
+    raise ValueError(msg)
 
 
 class Patchelf(ElfPatcher):

--- a/src/auditwheel/patcher.py
+++ b/src/auditwheel/patcher.py
@@ -124,7 +124,10 @@ class Patchelf(ElfPatcher):
         return output.removesuffix(" (legacy)")
 
     def apply_updates(self) -> None:
-        for filepath, update_info in self._updates.items():
+        elf_files = list(self._updates.keys())
+        for filepath in elf_files:
+            # prevent re-applying by removing from self._updates
+            update_info = self._updates.pop(filepath)
             args = []
             if update_info.soname is not None:
                 args.extend(["--set-soname", update_info.soname])
@@ -150,3 +153,4 @@ class Patchelf(ElfPatcher):
                 args.extend(set_args)
             if args:
                 check_call([self._patchelf_path, *args, filepath])
+        assert len(self._updates) == 0  # noqa: S101

--- a/src/auditwheel/patcher.py
+++ b/src/auditwheel/patcher.py
@@ -67,11 +67,11 @@ class ElfPatcher:
 
     def get_rpath(self, file_name: Path) -> str:
         key = str(file_name.resolve(strict=True))
-        update_info = self._updates[key]
-        if update_info.rpath is not None:
-            return update_info.rpath
-        if update_info.clear_rpath:
-            return ""
+        if update_info := self._updates.get(key, None):
+            if update_info.rpath is not None:
+                return update_info.rpath
+            if update_info.clear_rpath:
+                return ""
         return self.get_rpath_direct(file_name)
 
     def clear_rpath(self, file_name: Path) -> None:

--- a/src/auditwheel/patcher.py
+++ b/src/auditwheel/patcher.py
@@ -27,46 +27,42 @@ class ElfUpdateInfo:
 class ElfPatcher:
     def __init__(self, platform: str) -> None:
         self.platform = platform
-        self._updates: dict[str, ElfUpdateInfo] = defaultdict(ElfUpdateInfo)
+        self._updates: dict[Path, ElfUpdateInfo] = defaultdict(ElfUpdateInfo)
 
     @staticmethod
     def _needed_overlap(removed: Iterable[str], replaced: Iterable[tuple[str, str]]) -> str | None:
-        for soname in removed:
-            for org_soname, new_soname in replaced:
-                if soname in (org_soname, new_soname):
-                    return soname
-        return None
+        replaced_sonames = set(chain.from_iterable(replaced))
+        return next((name for name in removed if name in replaced_sonames), None)
+
+    def _update_for(self, file_name: Path) -> ElfUpdateInfo:
+        return self._updates[file_name.resolve(strict=True)]
 
     def replace_needed(self, file_name: Path, *old_new_pairs: tuple[str, str]) -> None:
-        key = str(file_name.resolve(strict=True))
-        update_info = self._updates[key]
+        update_info = self._update_for(file_name)
         if overlap_soname := ElfPatcher._needed_overlap(update_info.remove_needed, old_new_pairs):
             msg = f"can't add replace_needed entry, {overlap_soname!r} has been removed"
             raise ValueError(msg)
         update_info.replace_needed.extend(old_new_pairs)
 
     def remove_needed(self, file_name: Path, *sonames: str) -> None:
-        key = str(file_name.resolve(strict=True))
-        update_info = self._updates[key]
+        update_info = self._update_for(file_name)
         if overlap_soname := ElfPatcher._needed_overlap(sonames, update_info.replace_needed):
             msg = f"can't remove {overlap_soname!r} as it's part of the replace_needed entries"
             raise ValueError(msg)
         update_info.remove_needed.extend(sonames)
 
     def set_soname(self, file_name: Path, new_so_name: str) -> None:
-        key = str(file_name.resolve(strict=True))
-        self._updates[key].soname = new_so_name
+        self._update_for(file_name).soname = new_so_name
 
     def set_rpath(self, file_name: Path, rpath: str) -> None:
         # https://android.googlesource.com/platform/bionic/+/refs/heads/main/android-changes-for-ndk-developers.md
         if self.platform.startswith("android") and android_api_level(self.platform) < 24:
             msg = "Grafting libraries with RUNPATH requires API level 24 or higher"
             raise ValueError(msg)
-        key = str(file_name.resolve(strict=True))
-        self._updates[key].rpath = rpath
+        self._update_for(file_name).rpath = rpath
 
     def get_rpath(self, file_name: Path) -> str:
-        key = str(file_name.resolve(strict=True))
+        key = file_name.resolve(strict=True)
         if update_info := self._updates.get(key, None):
             if update_info.rpath is not None:
                 return update_info.rpath
@@ -75,13 +71,12 @@ class ElfPatcher:
         return self.get_rpath_direct(file_name)
 
     def clear_rpath(self, file_name: Path) -> None:
-        key = str(file_name.resolve(strict=True))
-        self._updates[key].clear_rpath = True
+        self._update_for(file_name).clear_rpath = True
 
     def update_elf_path(self, old_file_name: Path, new_file_name: Path) -> None:
-        old_key = str(old_file_name.resolve(strict=True))
-        new_key = str(new_file_name.resolve(strict=True))
+        old_key = old_file_name.resolve(strict=True)
         if old_key in self._updates:
+            new_key = new_file_name.resolve(strict=True)
             self._updates[new_key] = self._updates.pop(old_key)
 
     def get_rpath_direct(self, file_name: Path) -> str:
@@ -119,9 +114,8 @@ class Patchelf(ElfPatcher):
         self._patchelf_path = str(_verify_patchelf())
 
     def get_rpath_direct(self, file_name: Path) -> str:
-        args = ("--print-rpath", file_name)
-        output = check_output([self._patchelf_path, *args]).decode("utf-8").strip()
-        return output.removesuffix(" (legacy)")
+        output = check_output([self._patchelf_path, "--print-rpath", file_name])
+        return output.decode("utf-8").strip().removesuffix(" (legacy)")
 
     def apply_updates(self) -> None:
         elf_files = list(self._updates.keys())

--- a/src/auditwheel/patcher.py
+++ b/src/auditwheel/patcher.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import dataclasses
 import re
+from collections import defaultdict
 from itertools import chain
+from pathlib import Path
 from shutil import which
 from subprocess import CalledProcessError, check_call, check_output
 from typing import TYPE_CHECKING
@@ -9,55 +12,103 @@ from typing import TYPE_CHECKING
 from auditwheel.wheeltools import android_api_level
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from collections.abc import Iterable
+
+
+@dataclasses.dataclass()
+class ElfUpdateInfo:
+    soname: str | None = None
+    rpath: str | None = None
+    remove_needed: list[str] = dataclasses.field(default_factory=list)
+    replace_needed: list[tuple[str, str]] = dataclasses.field(default_factory=list)
+    clear_rpath: bool = False
 
 
 class ElfPatcher:
     def __init__(self, platform: str) -> None:
         self.platform = platform
+        self._updates: dict[str, ElfUpdateInfo] = defaultdict(ElfUpdateInfo)
+
+    @staticmethod
+    def _needed_overlap(removed: Iterable[str], replaced: Iterable[tuple[str, str]]) -> str | None:
+        for soname in removed:
+            for org_soname, new_soname in replaced:
+                if soname in (org_soname, new_soname):
+                    return soname
+        return None
 
     def replace_needed(self, file_name: Path, *old_new_pairs: tuple[str, str]) -> None:
-        raise NotImplementedError
+        key = str(file_name.resolve(strict=True))
+        update_info = self._updates[key]
+        if overlap_soname := ElfPatcher._needed_overlap(update_info.remove_needed, old_new_pairs):
+            msg = f"can't add replace_needed entry, {overlap_soname!r} has been removed"
+            raise ValueError(msg)
+        update_info.replace_needed.extend(old_new_pairs)
 
     def remove_needed(self, file_name: Path, *sonames: str) -> None:
-        raise NotImplementedError
+        key = str(file_name.resolve(strict=True))
+        update_info = self._updates[key]
+        if overlap_soname := ElfPatcher._needed_overlap(sonames, update_info.replace_needed):
+            msg = f"can't remove {overlap_soname!r} as it's part of the replace_needed entries"
+            raise ValueError(msg)
+        update_info.remove_needed.extend(sonames)
 
     def set_soname(self, file_name: Path, new_so_name: str) -> None:
-        raise NotImplementedError
+        key = str(file_name.resolve(strict=True))
+        self._updates[key].soname = new_so_name
 
-    def check_rpath_support(self) -> None:
+    def set_rpath(self, file_name: Path, rpath: str) -> None:
         # https://android.googlesource.com/platform/bionic/+/refs/heads/main/android-changes-for-ndk-developers.md
         if self.platform.startswith("android") and android_api_level(self.platform) < 24:
             msg = "Grafting libraries with RUNPATH requires API level 24 or higher"
             raise ValueError(msg)
-
-    def set_rpath(self, file_name: Path, rpath: str) -> None:
-        raise NotImplementedError
+        key = str(file_name.resolve(strict=True))
+        self._updates[key].rpath = rpath
 
     def get_rpath(self, file_name: Path) -> str:
-        raise NotImplementedError
+        key = str(file_name.resolve(strict=True))
+        update_info = self._updates[key]
+        if update_info.rpath is not None:
+            return update_info.rpath
+        if update_info.clear_rpath:
+            return ""
+        return self.get_rpath_direct(file_name)
 
     def clear_rpath(self, file_name: Path) -> None:
+        key = str(file_name.resolve(strict=True))
+        self._updates[key].clear_rpath = True
+
+    def update_elf_path(self, old_file_name: Path, new_file_name: Path) -> None:
+        old_key = str(old_file_name.resolve(strict=True))
+        new_key = str(new_file_name.resolve(strict=True))
+        if old_key in self._updates:
+            self._updates[new_key] = self._updates.pop(old_key)
+
+    def get_rpath_direct(self, file_name: Path) -> str:
+        raise NotImplementedError
+
+    def apply_updates(self) -> None:
         raise NotImplementedError
 
 
-def _verify_patchelf() -> None:
+def _verify_patchelf() -> Path:
     """This function looks for the ``patchelf`` external binary in the PATH,
     checks for the required version, and throws an exception if a proper
     version can't be found. Otherwise, silence is golden
     """
-    if not which("patchelf"):
+    patchelf_path = which("patchelf")
+    if not patchelf_path:
         msg = "Cannot find required utility `patchelf` in PATH"
         raise ValueError(msg)
     try:
-        version = check_output(["patchelf", "--version"]).decode("utf-8")
+        version = check_output([patchelf_path, "--version"]).decode("utf-8")
     except CalledProcessError:
         msg = "Could not call `patchelf` binary"
         raise ValueError(msg) from None
 
     m = re.match(r"patchelf\s+(\d+(.\d+)?)", version)
     if m and tuple(int(x) for x in m.group(1).split(".")) >= (0, 14):
-        return
+        return Path(patchelf_path)
     msg = f"patchelf {version} found. auditwheel repair requires patchelf >= 0.14."
     raise ValueError(msg)
 
@@ -65,43 +116,37 @@ def _verify_patchelf() -> None:
 class Patchelf(ElfPatcher):
     def __init__(self, platform: str = "") -> None:
         super().__init__(platform)
-        _verify_patchelf()
+        self._patchelf_path = str(_verify_patchelf())
 
-    def replace_needed(self, file_name: Path, *old_new_pairs: tuple[str, str]) -> None:
-        check_call(
-            [
-                "patchelf",
-                *chain.from_iterable(("--replace-needed", *pair) for pair in old_new_pairs),
-                file_name,
-            ],
-        )
+    def get_rpath_direct(self, file_name: Path) -> str:
+        args = ("--print-rpath", file_name)
+        output = check_output([self._patchelf_path, *args]).decode("utf-8").strip()
+        return output.removesuffix(" (legacy)")
 
-    def remove_needed(self, file_name: Path, *sonames: str) -> None:
-        check_call(
-            [
-                "patchelf",
-                *chain.from_iterable(("--remove-needed", soname) for soname in sonames),
-                file_name,
-            ],
-        )
-
-    def set_soname(self, file_name: Path, new_so_name: str) -> None:
-        check_call(["patchelf", "--set-soname", new_so_name, file_name])
-
-    def set_rpath(self, file_name: Path, rpath: str) -> None:
-        self.check_rpath_support()
-
-        set_args: list[str | Path] = ["patchelf", "--force-rpath", "--set-rpath", rpath, file_name]
-        if self.platform.startswith("android"):
-            # Android supports only RUNPATH, not RPATH.
-            set_args.remove("--force-rpath")
-
-        # we only want an RPATH, remove RUNPATH/RPATH altogether in a 1st pass
-        check_call(["patchelf", "--remove-rpath", file_name])
-        check_call(set_args)
-
-    def get_rpath(self, file_name: Path) -> str:
-        return check_output(["patchelf", "--print-rpath", file_name]).decode("utf-8").strip()
-
-    def clear_rpath(self, file_name: Path) -> None:
-        check_call(["patchelf", "--remove-rpath", file_name])
+    def apply_updates(self) -> None:
+        for filepath, update_info in self._updates.items():
+            args = []
+            if update_info.soname is not None:
+                args.extend(["--set-soname", update_info.soname])
+            if update_info.remove_needed:
+                args.extend(
+                    chain.from_iterable(
+                        ("--remove-needed", soname) for soname in update_info.remove_needed
+                    ),
+                )
+            if update_info.replace_needed:
+                args.extend(
+                    chain.from_iterable(
+                        ("--replace-needed", *pair) for pair in update_info.replace_needed
+                    ),
+                )
+            if update_info.clear_rpath and update_info.rpath is None:
+                args.append("--remove-rpath")
+            if update_info.rpath is not None:
+                set_args = ["--force-rpath", "--set-rpath", update_info.rpath]
+                if self.platform.startswith("android"):
+                    # Android supports only RUNPATH, not RPATH.
+                    set_args.remove("--force-rpath")
+                args.extend(set_args)
+            if args:
+                check_call([self._patchelf_path, *args, filepath])

--- a/src/auditwheel/patcher.py
+++ b/src/auditwheel/patcher.py
@@ -109,8 +109,7 @@ def _verify_patchelf() -> Path:
     m = re.match(r"patchelf\s+(\d+(.\d+)?)", version)
     if m and tuple(int(x) for x in m.group(1).split(".")) >= (0, 14):
         return Path(patchelf_path)
-    msg = f"patchelf {version} found. auditwheel repair requires patchelf >= 0.14."
-    raise ValueError(msg)
+    msg = f"{version.strip()} found. auditwheel repair requires patchelf >= 0.14."
 
 
 class Patchelf(ElfPatcher):

--- a/src/auditwheel/repair.py
+++ b/src/auditwheel/repair.py
@@ -105,6 +105,7 @@ def repair_wheel(
                 new_fn = fn
                 if _path_is_script(fn):
                     new_fn = _replace_elf_script_with_shim(match.group("name"), fn)
+                    patcher.update_elf_path(fn, new_fn)
                 new_rpath = Path("$ORIGIN") / os.path.relpath(dest_dir, new_fn.parent)
                 append_rpath_within_wheel(new_fn, str(new_rpath), ctx.name, patcher)
 
@@ -124,6 +125,8 @@ def repair_wheel(
                 patcher.replace_needed(path, *replacements)
             else:
                 patcher.clear_rpath(path)
+
+        patcher.apply_updates()
 
         if update_tags:
             output_wheel = add_platforms(ctx, abis, get_replace_platforms(abis[0]))

--- a/tests/unit/test_elfpatcher.py
+++ b/tests/unit/test_elfpatcher.py
@@ -1,12 +1,33 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from subprocess import CalledProcessError
 from unittest.mock import call, patch
 
 import pytest
 
-from auditwheel.patcher import Patchelf
+from auditwheel.patcher import ElfPatcher, Patchelf
+
+
+def test_elfpatcher_replace_needed_overlap(tmp_path):
+    filename = tmp_path / "test.so"
+    filename.touch()
+    patcher = ElfPatcher("")
+    patcher.remove_needed(filename, "removed")
+    with pytest.raises(ValueError, match=re.escape("can't add replace_needed entry")):
+        patcher.replace_needed(filename, ("removed", "replaced"))
+
+
+def test_elfpatcher_remove_needed_overlap(tmp_path):
+    filename = tmp_path / "test.so"
+    filename.touch()
+    patcher = ElfPatcher("")
+    patcher.replace_needed(filename, ("original", "replaced"))
+    with pytest.raises(ValueError, match=re.escape("can't remove")):
+        patcher.remove_needed(filename, "original")
+    with pytest.raises(ValueError, match=re.escape("can't remove")):
+        patcher.remove_needed(filename, "replaced")
 
 
 @patch("auditwheel.patcher.which")
@@ -29,7 +50,7 @@ def test_patchelf_check_output_fail(check_output, which):
 @patch("auditwheel.patcher.check_output")
 @pytest.mark.parametrize("version", ["0.14", "0.14.1", "0.15"])
 def test_patchelf_version_check(check_output, which, version):
-    which.return_value = True
+    which.return_value = "patchelf"
     check_output.return_value.decode.return_value = f"patchelf {version}"
     Patchelf()
 
@@ -50,24 +71,32 @@ def test_patchelf_version_check_fail(check_output, which, version):
 class TestPatchElf:
     """ "Validate that patchelf is invoked with the correct arguments."""
 
-    def test_replace_needed_one(self, check_call, _0, _1):  # noqa: PT019
+    def test_replace_needed_one(self, check_call, _0, _1, tmp_path):  # noqa: PT019
         patcher = Patchelf()
-        filename = Path("test.so")
+        patcher._patchelf_path = "patchelf"
+        filename = tmp_path / "test.so"
+        filename.touch()
+        filename_str = str(filename.resolve(strict=True))
         soname_old = "TEST_OLD"
         soname_new = "TEST_NEW"
         patcher.replace_needed(filename, (soname_old, soname_new))
+        patcher.apply_updates()
         check_call.assert_called_once_with(
-            ["patchelf", "--replace-needed", soname_old, soname_new, filename],
+            ["patchelf", "--replace-needed", soname_old, soname_new, filename_str],
         )
 
-    def test_replace_needed_multple(self, check_call, _0, _1):  # noqa: PT019
+    def test_replace_needed_multiple(self, check_call, _0, _1, tmp_path):  # noqa: PT019
         patcher = Patchelf()
-        filename = Path("test.so")
+        patcher._patchelf_path = "patchelf"
+        filename = tmp_path / "test.so"
+        filename.touch()
+        filename_str = str(filename.resolve(strict=True))
         replacements = [
             ("TEST_OLD1", "TEST_NEW1"),
             ("TEST_OLD2", "TEST_NEW2"),
         ]
         patcher.replace_needed(filename, *replacements)
+        patcher.apply_updates()
         check_call.assert_called_once_with(
             [
                 "patchelf",
@@ -75,34 +104,37 @@ class TestPatchElf:
                 *replacements[0],
                 "--replace-needed",
                 *replacements[1],
-                filename,
+                filename_str,
             ],
         )
 
-    def test_set_soname(self, check_call, _0, _1):  # noqa: PT019
+    def test_set_soname(self, check_call, _0, _1, tmp_path):  # noqa: PT019
         patcher = Patchelf()
-        filename = Path("test.so")
+        patcher._patchelf_path = "patchelf"
+        filename = tmp_path / "test.so"
+        filename.touch()
+        filename_str = str(filename.resolve(strict=True))
         soname_new = "TEST_NEW"
         patcher.set_soname(filename, soname_new)
+        patcher.apply_updates()
         check_call.assert_called_once_with(
-            ["patchelf", "--set-soname", soname_new, filename],
+            ["patchelf", "--set-soname", soname_new, filename_str],
         )
 
     @pytest.mark.parametrize("platform", ["android_24_x86_64", "manylinux_2_26_x86_64"])
-    def test_set_rpath(self, check_call, _0, _1, platform):  # noqa: PT019
+    def test_set_rpath(self, check_call, _0, _1, platform, tmp_path):  # noqa: PT019
         patcher = Patchelf(platform)
-        filename = Path("test.so")
+        patcher._patchelf_path = "patchelf"
+        filename = tmp_path / "test.so"
+        filename.touch()
+        filename_str = str(filename.resolve(strict=True))
         patcher.set_rpath(filename, "$ORIGIN/.lib")
-        check_call_expected_args = [
-            call(["patchelf", "--remove-rpath", filename]),
-            call(
-                ["patchelf"]
-                + ([] if platform.startswith("android") else ["--force-rpath"])
-                + ["--set-rpath", "$ORIGIN/.lib", filename],
-            ),
-        ]
-
-        assert check_call.call_args_list == check_call_expected_args
+        patcher.apply_updates()
+        check_call.assert_called_once_with(
+            ["patchelf"]
+            + ([] if platform.startswith("android") else ["--force-rpath"])
+            + ["--set-rpath", "$ORIGIN/.lib", filename_str],
+        )
 
     def test_set_rpath_android_old(self, check_call, _0, _1):  # noqa: PT019
         patcher = Patchelf("android_23_x86_64")
@@ -111,9 +143,11 @@ class TestPatchElf:
             patcher.set_rpath(filename, "$ORIGIN/.lib")
         check_call.assert_not_called()
 
-    def test_get_rpath(self, _0, check_output, _1):  # noqa: PT019
+    def test_get_rpath(self, _0, check_output, _1, tmp_path):  # noqa: PT019
         patcher = Patchelf()
-        filename = Path("test.so")
+        patcher._patchelf_path = "patchelf"
+        filename = tmp_path / "test.so"
+        filename.touch()
         check_output.return_value = b"existing_rpath"
         result = patcher.get_rpath(filename)
         check_output_expected_args = [call(["patchelf", "--print-rpath", filename])]
@@ -121,12 +155,16 @@ class TestPatchElf:
         assert result == check_output.return_value.decode()
         assert check_output.call_args_list == check_output_expected_args
 
-    def test_remove_needed(self, check_call, _0, _1):  # noqa: PT019
+    def test_remove_needed(self, check_call, _0, _1, tmp_path):  # noqa: PT019
         patcher = Patchelf()
-        filename = Path("test.so")
+        patcher._patchelf_path = "patchelf"
+        filename = tmp_path / "test.so"
+        filename.touch()
+        filename_str = str(filename.resolve(strict=True))
         soname_1 = "TEST_REM_1"
         soname_2 = "TEST_REM_2"
         patcher.remove_needed(filename, soname_1, soname_2)
+        patcher.apply_updates()
         check_call.assert_called_once_with(
             [
                 "patchelf",
@@ -134,16 +172,20 @@ class TestPatchElf:
                 soname_1,
                 "--remove-needed",
                 soname_2,
-                filename,
+                filename_str,
             ],
         )
 
-    def test_clear_rpath(self, check_call, _0, _1):  # noqa: PT019
+    def test_clear_rpath(self, check_call, _0, _1, tmp_path):  # noqa: PT019
         patcher = Patchelf()
-        filename = Path("test.so")
+        patcher._patchelf_path = "patchelf"
+        filename = tmp_path / "test.so"
+        filename.touch()
+        filename_str = str(filename.resolve(strict=True))
         patcher.clear_rpath(filename)
+        patcher.apply_updates()
         check_call_expected_args = [
-            call(["patchelf", "--remove-rpath", filename]),
+            call(["patchelf", "--remove-rpath", filename_str]),
         ]
 
         assert check_call.call_args_list == check_call_expected_args

--- a/tests/unit/test_elfpatcher.py
+++ b/tests/unit/test_elfpatcher.py
@@ -229,3 +229,13 @@ class TestPatchElf:
         ]
 
         assert check_call.call_args_list == check_call_expected_args
+
+    def test_no_update(self, check_call, _0, _1, tmp_path):  # noqa: PT019
+        patcher = Patchelf()
+        patcher._patchelf_path = "patchelf"
+        filename = tmp_path / "test.so"
+        filename.touch()
+        # create update info but do not update anything
+        assert patcher._update_for(filename).clear_rpath is False
+        patcher.apply_updates()
+        assert check_call.call_args_list == []

--- a/tests/unit/test_elfpatcher.py
+++ b/tests/unit/test_elfpatcher.py
@@ -69,7 +69,7 @@ def test_patchelf_version_check_fail(check_output, which, version):
 @patch("auditwheel.patcher.check_output")
 @patch("auditwheel.patcher.check_call")
 class TestPatchElf:
-    """ "Validate that patchelf is invoked with the correct arguments."""
+    """Validate that patchelf is invoked with the correct arguments."""
 
     def test_replace_needed_one(self, check_call, _0, _1, tmp_path):  # noqa: PT019
         patcher = Patchelf()

--- a/tests/unit/test_elfpatcher.py
+++ b/tests/unit/test_elfpatcher.py
@@ -116,13 +116,13 @@ class TestPatchElf:
         patcher._patchelf_path = "patchelf"
         filename = tmp_path / "test.so"
         filename.touch()
-        filename_str = str(filename.resolve(strict=True))
+        filename_key = filename.resolve(strict=True)
         soname_old = "TEST_OLD"
         soname_new = "TEST_NEW"
         patcher.replace_needed(filename, (soname_old, soname_new))
         patcher.apply_updates()
         check_call.assert_called_once_with(
-            ["patchelf", "--replace-needed", soname_old, soname_new, filename_str],
+            ["patchelf", "--replace-needed", soname_old, soname_new, filename_key],
         )
 
     def test_replace_needed_multiple(self, check_call, _0, _1, tmp_path):  # noqa: PT019
@@ -130,7 +130,7 @@ class TestPatchElf:
         patcher._patchelf_path = "patchelf"
         filename = tmp_path / "test.so"
         filename.touch()
-        filename_str = str(filename.resolve(strict=True))
+        filename_key = filename.resolve(strict=True)
         replacements = [
             ("TEST_OLD1", "TEST_NEW1"),
             ("TEST_OLD2", "TEST_NEW2"),
@@ -144,7 +144,7 @@ class TestPatchElf:
                 *replacements[0],
                 "--replace-needed",
                 *replacements[1],
-                filename_str,
+                filename_key,
             ],
         )
 
@@ -153,12 +153,12 @@ class TestPatchElf:
         patcher._patchelf_path = "patchelf"
         filename = tmp_path / "test.so"
         filename.touch()
-        filename_str = str(filename.resolve(strict=True))
+        filename_key = filename.resolve(strict=True)
         soname_new = "TEST_NEW"
         patcher.set_soname(filename, soname_new)
         patcher.apply_updates()
         check_call.assert_called_once_with(
-            ["patchelf", "--set-soname", soname_new, filename_str],
+            ["patchelf", "--set-soname", soname_new, filename_key],
         )
 
     @pytest.mark.parametrize("platform", ["android_24_x86_64", "manylinux_2_26_x86_64"])
@@ -167,13 +167,13 @@ class TestPatchElf:
         patcher._patchelf_path = "patchelf"
         filename = tmp_path / "test.so"
         filename.touch()
-        filename_str = str(filename.resolve(strict=True))
+        filename_key = filename.resolve(strict=True)
         patcher.set_rpath(filename, "$ORIGIN/.lib")
         patcher.apply_updates()
         check_call.assert_called_once_with(
             ["patchelf"]
             + ([] if platform.startswith("android") else ["--force-rpath"])
-            + ["--set-rpath", "$ORIGIN/.lib", filename_str],
+            + ["--set-rpath", "$ORIGIN/.lib", filename_key],
         )
 
     def test_set_rpath_android_old(self, check_call, _0, _1):  # noqa: PT019
@@ -200,7 +200,7 @@ class TestPatchElf:
         patcher._patchelf_path = "patchelf"
         filename = tmp_path / "test.so"
         filename.touch()
-        filename_str = str(filename.resolve(strict=True))
+        filename_key = filename.resolve(strict=True)
         soname_1 = "TEST_REM_1"
         soname_2 = "TEST_REM_2"
         patcher.remove_needed(filename, soname_1, soname_2)
@@ -212,7 +212,7 @@ class TestPatchElf:
                 soname_1,
                 "--remove-needed",
                 soname_2,
-                filename_str,
+                filename_key,
             ],
         )
 
@@ -221,11 +221,11 @@ class TestPatchElf:
         patcher._patchelf_path = "patchelf"
         filename = tmp_path / "test.so"
         filename.touch()
-        filename_str = str(filename.resolve(strict=True))
+        filename_key = filename.resolve(strict=True)
         patcher.clear_rpath(filename)
         patcher.apply_updates()
         check_call_expected_args = [
-            call(["patchelf", "--remove-rpath", filename_str]),
+            call(["patchelf", "--remove-rpath", filename_key]),
         ]
 
         assert check_call.call_args_list == check_call_expected_args

--- a/tests/unit/test_elfpatcher.py
+++ b/tests/unit/test_elfpatcher.py
@@ -46,6 +46,30 @@ def test_elfpatcher_get_rpath_removed(tmp_path):
     assert patcher.get_rpath(filename) == ""
 
 
+def test_elfpatcher_update_elf_path(tmp_path):
+    filename1 = tmp_path / "test1.so"
+    filename1.touch()
+    filename2 = tmp_path / "test2.so"
+    filename2.touch()
+    patcher = ElfPatcher("")
+    patcher.clear_rpath(filename1)
+    patcher.update_elf_path(filename1, filename2)
+    assert len(patcher._updates) == 1
+    key, value = patcher._updates.popitem()
+    assert Path(key).samefile(filename2)
+    assert value.clear_rpath is True
+
+
+def test_elfpatcher_update_elf_path_noop(tmp_path):
+    filename1 = tmp_path / "test1.so"
+    filename1.touch()
+    filename2 = tmp_path / "test2.so"
+    filename2.touch()
+    patcher = ElfPatcher("")
+    patcher.update_elf_path(filename1, filename2)
+    assert len(patcher._updates) == 0
+
+
 @patch("auditwheel.patcher.which")
 def test_patchelf_unavailable(which):
     which.return_value = False

--- a/tests/unit/test_elfpatcher.py
+++ b/tests/unit/test_elfpatcher.py
@@ -30,6 +30,22 @@ def test_elfpatcher_remove_needed_overlap(tmp_path):
         patcher.remove_needed(filename, "replaced")
 
 
+def test_elfpatcher_get_rpath_replaced(tmp_path):
+    filename = tmp_path / "test.so"
+    filename.touch()
+    patcher = ElfPatcher("")
+    patcher.set_rpath(filename, "new-rpath")
+    assert patcher.get_rpath(filename) == "new-rpath"
+
+
+def test_elfpatcher_get_rpath_removed(tmp_path):
+    filename = tmp_path / "test.so"
+    filename.touch()
+    patcher = ElfPatcher("")
+    patcher.clear_rpath(filename)
+    assert patcher.get_rpath(filename) == ""
+
+
 @patch("auditwheel.patcher.which")
 def test_patchelf_unavailable(which):
     which.return_value = False

--- a/tests/unit/test_repair.py
+++ b/tests/unit/test_repair.py
@@ -1,117 +1,78 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import call, patch
 
-from auditwheel.patcher import Patchelf
+from auditwheel.patcher import ElfPatcher
 from auditwheel.repair import append_rpath_within_wheel
 
 
-@patch("auditwheel.patcher._verify_patchelf")
-@patch("auditwheel.patcher.check_output")
-@patch("auditwheel.patcher.check_call")
-class TestRepair:
-    def test_append_rpath(self, check_call, check_output, _):  # noqa: PT019
-        patcher = Patchelf()
-        # When a library has an existing RPATH entry within wheel_dir
-        existing_rpath = b"$ORIGIN/.existinglibdir"
-        check_output.return_value = existing_rpath
-        wheel_dir = Path.cwd()
-        lib_name = Path("test.so")
-        full_lib_name = lib_name.absolute()
-        append_rpath_within_wheel(lib_name, "$ORIGIN/.lib", wheel_dir, patcher)
-        check_output_expected_args = [
-            call(["patchelf", "--print-rpath", full_lib_name]),
-        ]
-        # Then that entry is preserved when updating the RPATH
-        check_call_expected_args = [
-            call(["patchelf", "--remove-rpath", full_lib_name]),
-            call(
-                [
-                    "patchelf",
-                    "--force-rpath",
-                    "--set-rpath",
-                    f"{existing_rpath.decode()}:$ORIGIN/.lib",
-                    full_lib_name,
-                ],
-            ),
-        ]
+class MockedELfPatcher(ElfPatcher):
+    def __init__(self, existing_rpath: str) -> None:
+        super().__init__("")
+        self._existing_rpath = existing_rpath
+        self.get_rpath_direct_called: list[Path] = []
 
-        assert check_output.call_args_list == check_output_expected_args
-        assert check_call.call_args_list == check_call_expected_args
+    def get_rpath_direct(self, file_name: Path) -> str:
+        self.get_rpath_direct_called.append(file_name)
+        return self._existing_rpath
 
-    def test_append_rpath_reject_outside_wheel(self, check_call, check_output, _):  # noqa: PT019
-        patcher = Patchelf()
-        # When a library has an existing RPATH entry outside wheel_dir
-        existing_rpath = b"/outside/wheel/dir"
-        check_output.return_value = existing_rpath
-        wheel_dir = Path("/not/outside")
-        lib_name = Path("test.so")
-        full_lib_name = lib_name.absolute()
-        append_rpath_within_wheel(lib_name, "$ORIGIN/.lib", wheel_dir, patcher)
-        check_output_expected_args = [
-            call(["patchelf", "--print-rpath", full_lib_name]),
-        ]
-        # Then that entry is eliminated when updating the RPATH
-        check_call_expected_args = [
-            call(["patchelf", "--remove-rpath", full_lib_name]),
-            call(
-                [
-                    "patchelf",
-                    "--force-rpath",
-                    "--set-rpath",
-                    "$ORIGIN/.lib",
-                    full_lib_name,
-                ],
-            ),
-        ]
 
-        assert check_output.call_args_list == check_output_expected_args
-        assert check_call.call_args_list == check_call_expected_args
+def test_append_rpath(tmp_path: Path) -> None:
+    # When a library has an existing RPATH entry within wheel_dir
+    existing_rpath = "$ORIGIN/.existinglibdir"
+    patcher = MockedELfPatcher(existing_rpath)
+    wheel_dir = tmp_path
+    lib_name = tmp_path / "test.so"
+    lib_name.touch()
+    full_lib_name = lib_name.absolute()
+    lib_name_str = str(lib_name.resolve(strict=True))
+    append_rpath_within_wheel(lib_name, "$ORIGIN/.lib", wheel_dir, patcher)
+    # Then that entry is preserved when updating the RPATH
+    assert patcher.get_rpath_direct_called == [full_lib_name]
+    assert patcher._updates[lib_name_str].rpath == f"{existing_rpath}:$ORIGIN/.lib"
 
-    def test_append_rpath_ignore_duplicates(self, check_call, check_output, _):  # noqa: PT019
-        patcher = Patchelf()
-        # When a library has an existing RPATH entry and we try and append it again
-        existing_rpath = b"$ORIGIN"
-        check_output.return_value = existing_rpath
-        wheel_dir = Path.cwd()
-        lib_name = Path("test.so")
-        full_lib_name = lib_name.absolute()
-        append_rpath_within_wheel(lib_name, "$ORIGIN", wheel_dir, patcher)
-        check_output_expected_args = [
-            call(["patchelf", "--print-rpath", full_lib_name]),
-        ]
-        # Then that entry is ignored when updating the RPATH
-        check_call_expected_args = [
-            call(["patchelf", "--remove-rpath", full_lib_name]),
-            call(
-                ["patchelf", "--force-rpath", "--set-rpath", "$ORIGIN", full_lib_name],
-            ),
-        ]
 
-        assert check_output.call_args_list == check_output_expected_args
-        assert check_call.call_args_list == check_call_expected_args
+def test_append_rpath_reject_outside_wheel(tmp_path: Path) -> None:
+    # When a library has an existing RPATH entry outside wheel_dir
+    existing_rpath = "/outside/wheel/dir"
+    patcher = MockedELfPatcher(existing_rpath)
+    wheel_dir = Path("/not/outside")
+    lib_name = tmp_path / "test.so"
+    lib_name.touch()
+    full_lib_name = lib_name.absolute()
+    lib_name_str = str(lib_name.resolve(strict=True))
+    append_rpath_within_wheel(lib_name, "$ORIGIN/.lib", wheel_dir, patcher)
+    # Then that entry is eliminated when updating the RPATH
+    assert patcher.get_rpath_direct_called == [full_lib_name]
+    assert patcher._updates[lib_name_str].rpath == "$ORIGIN/.lib"
 
-    def test_append_rpath_ignore_relative(self, check_call, check_output, _):  # noqa: PT019
-        patcher = Patchelf()
-        # When a library has an existing RPATH entry but it cannot be resolved
-        # to an absolute path, it is eliminated
-        existing_rpath = b"not/absolute"
-        check_output.return_value = existing_rpath
-        wheel_dir = Path.cwd()
-        lib_name = Path("test.so")
-        full_lib_name = lib_name.absolute()
-        append_rpath_within_wheel(lib_name, "$ORIGIN", wheel_dir, patcher)
-        check_output_expected_args = [
-            call(["patchelf", "--print-rpath", full_lib_name]),
-        ]
-        # Then that entry is ignored when updating the RPATH
-        check_call_expected_args = [
-            call(["patchelf", "--remove-rpath", full_lib_name]),
-            call(
-                ["patchelf", "--force-rpath", "--set-rpath", "$ORIGIN", full_lib_name],
-            ),
-        ]
 
-        assert check_output.call_args_list == check_output_expected_args
-        assert check_call.call_args_list == check_call_expected_args
+def test_append_rpath_ignore_duplicates(tmp_path: Path) -> None:
+    # When a library has an existing RPATH entry and we try and append it again
+    existing_rpath = "$ORIGIN"
+    patcher = MockedELfPatcher(existing_rpath)
+    wheel_dir = tmp_path
+    lib_name = tmp_path / "test.so"
+    lib_name.touch()
+    full_lib_name = lib_name.absolute()
+    lib_name_str = str(lib_name.resolve(strict=True))
+    append_rpath_within_wheel(lib_name, "$ORIGIN", wheel_dir, patcher)
+    # Then that entry is ignored when updating the RPATH
+    assert patcher.get_rpath_direct_called == [full_lib_name]
+    assert patcher._updates[lib_name_str].rpath == "$ORIGIN"
+
+
+def test_append_rpath_ignore_relative(tmp_path: Path) -> None:
+    # When a library has an existing RPATH entry but it cannot be resolved
+    # to an absolute path, it is eliminated
+    existing_rpath = "not/absolute"
+    patcher = MockedELfPatcher(existing_rpath)
+    wheel_dir = tmp_path
+    lib_name = tmp_path / "test.so"
+    lib_name.touch()
+    full_lib_name = lib_name.absolute()
+    lib_name_str = str(lib_name.resolve(strict=True))
+    append_rpath_within_wheel(lib_name, "$ORIGIN", wheel_dir, patcher)
+    # Then that entry is ignored when updating the RPATH
+    assert patcher.get_rpath_direct_called == [full_lib_name]
+    assert patcher._updates[lib_name_str].rpath == "$ORIGIN"

--- a/tests/unit/test_repair.py
+++ b/tests/unit/test_repair.py
@@ -25,11 +25,11 @@ def test_append_rpath(tmp_path: Path) -> None:
     lib_name = tmp_path / "test.so"
     lib_name.touch()
     full_lib_name = lib_name.absolute()
-    lib_name_str = str(lib_name.resolve(strict=True))
+    lib_name_key = lib_name.resolve(strict=True)
     append_rpath_within_wheel(lib_name, "$ORIGIN/.lib", wheel_dir, patcher)
     # Then that entry is preserved when updating the RPATH
     assert patcher.get_rpath_direct_called == [full_lib_name]
-    assert patcher._updates[lib_name_str].rpath == f"{existing_rpath}:$ORIGIN/.lib"
+    assert patcher._updates[lib_name_key].rpath == f"{existing_rpath}:$ORIGIN/.lib"
 
 
 def test_append_rpath_reject_outside_wheel(tmp_path: Path) -> None:
@@ -40,11 +40,11 @@ def test_append_rpath_reject_outside_wheel(tmp_path: Path) -> None:
     lib_name = tmp_path / "test.so"
     lib_name.touch()
     full_lib_name = lib_name.absolute()
-    lib_name_str = str(lib_name.resolve(strict=True))
+    lib_name_key = lib_name.resolve(strict=True)
     append_rpath_within_wheel(lib_name, "$ORIGIN/.lib", wheel_dir, patcher)
     # Then that entry is eliminated when updating the RPATH
     assert patcher.get_rpath_direct_called == [full_lib_name]
-    assert patcher._updates[lib_name_str].rpath == "$ORIGIN/.lib"
+    assert patcher._updates[lib_name_key].rpath == "$ORIGIN/.lib"
 
 
 def test_append_rpath_ignore_duplicates(tmp_path: Path) -> None:
@@ -55,11 +55,11 @@ def test_append_rpath_ignore_duplicates(tmp_path: Path) -> None:
     lib_name = tmp_path / "test.so"
     lib_name.touch()
     full_lib_name = lib_name.absolute()
-    lib_name_str = str(lib_name.resolve(strict=True))
+    lib_name_key = lib_name.resolve(strict=True)
     append_rpath_within_wheel(lib_name, "$ORIGIN", wheel_dir, patcher)
     # Then that entry is ignored when updating the RPATH
     assert patcher.get_rpath_direct_called == [full_lib_name]
-    assert patcher._updates[lib_name_str].rpath == "$ORIGIN"
+    assert patcher._updates[lib_name_key].rpath == "$ORIGIN"
 
 
 def test_append_rpath_ignore_relative(tmp_path: Path) -> None:
@@ -71,8 +71,8 @@ def test_append_rpath_ignore_relative(tmp_path: Path) -> None:
     lib_name = tmp_path / "test.so"
     lib_name.touch()
     full_lib_name = lib_name.absolute()
-    lib_name_str = str(lib_name.resolve(strict=True))
+    lib_name_key = lib_name.resolve(strict=True)
     append_rpath_within_wheel(lib_name, "$ORIGIN", wheel_dir, patcher)
     # Then that entry is ignored when updating the RPATH
     assert patcher.get_rpath_direct_called == [full_lib_name]
-    assert patcher._updates[lib_name_str].rpath == "$ORIGIN"
+    assert patcher._updates[lib_name_key].rpath == "$ORIGIN"

--- a/tests/unit/test_repair.py
+++ b/tests/unit/test_repair.py
@@ -6,7 +6,7 @@ from auditwheel.patcher import ElfPatcher
 from auditwheel.repair import append_rpath_within_wheel
 
 
-class MockedELfPatcher(ElfPatcher):
+class MockedElfPatcher(ElfPatcher):
     def __init__(self, existing_rpath: str) -> None:
         super().__init__("")
         self._existing_rpath = existing_rpath
@@ -20,7 +20,7 @@ class MockedELfPatcher(ElfPatcher):
 def test_append_rpath(tmp_path: Path) -> None:
     # When a library has an existing RPATH entry within wheel_dir
     existing_rpath = "$ORIGIN/.existinglibdir"
-    patcher = MockedELfPatcher(existing_rpath)
+    patcher = MockedElfPatcher(existing_rpath)
     wheel_dir = tmp_path
     lib_name = tmp_path / "test.so"
     lib_name.touch()
@@ -35,7 +35,7 @@ def test_append_rpath(tmp_path: Path) -> None:
 def test_append_rpath_reject_outside_wheel(tmp_path: Path) -> None:
     # When a library has an existing RPATH entry outside wheel_dir
     existing_rpath = "/outside/wheel/dir"
-    patcher = MockedELfPatcher(existing_rpath)
+    patcher = MockedElfPatcher(existing_rpath)
     wheel_dir = Path("/not/outside")
     lib_name = tmp_path / "test.so"
     lib_name.touch()
@@ -50,7 +50,7 @@ def test_append_rpath_reject_outside_wheel(tmp_path: Path) -> None:
 def test_append_rpath_ignore_duplicates(tmp_path: Path) -> None:
     # When a library has an existing RPATH entry and we try and append it again
     existing_rpath = "$ORIGIN"
-    patcher = MockedELfPatcher(existing_rpath)
+    patcher = MockedElfPatcher(existing_rpath)
     wheel_dir = tmp_path
     lib_name = tmp_path / "test.so"
     lib_name.touch()
@@ -66,7 +66,7 @@ def test_append_rpath_ignore_relative(tmp_path: Path) -> None:
     # When a library has an existing RPATH entry but it cannot be resolved
     # to an absolute path, it is eliminated
     existing_rpath = "not/absolute"
-    patcher = MockedELfPatcher(existing_rpath)
+    patcher = MockedElfPatcher(existing_rpath)
     wheel_dir = tmp_path
     lib_name = tmp_path / "test.so"
     lib_name.touch()


### PR DESCRIPTION
patchelf is called multiple times to update soname, remove/replace needed, update RPATH.

This can be done in a single command line call allowing for faster patching and reducing the chance of running into a patchelf issue with multiple updates to a single ELF file.