### PR TITLE
fix: add assertion for image.id to satisfy mypy

### DIFF
--- a/tests/integration/test_manylinux.py
+++ b/tests/integration/test_manylinux.py
@@ -406,6 +406,7 @@ def tmp_docker_image(
     finally:
         client = image.client
         assert client is not None
+        assert image.id is not None
         client.images.remove(image.id)
 
 


### PR DESCRIPTION
image.id is typed as str | None by the docker library, but images.remove() expects str. Add an assertion to narrow the type.