### PR TITLE
fix: sort SBOM components deterministically

### DIFF
--- a/src/auditwheel/sboms.py
+++ b/src/auditwheel/sboms.py
@@ -67,7 +67,7 @@ def create_sbom_for_wheel(
         "dependencies": sbom_dependencies,
     }
 
-    for filepath, provided_by in sbom_packages.items():
+    for filepath, provided_by in sorted(sbom_packages.items(), key=lambda kv: (kv[1].purl, kv[0])):
         bom_ref = (
             provided_by.purl + f"#{hashlib.sha256(filepath.encode(errors='ignore')).hexdigest()}"
         )

--- a/tests/unit/test_sboms.py
+++ b/tests/unit/test_sboms.py
@@ -71,3 +71,44 @@ def test_create_sbom(whichprovides):
             },
         ],
     }
+
+
+@patch("auditwheel.sboms.whichprovides")
+def test_create_sbom_component_order_is_deterministic(whichprovides):
+    # Two .so files from the same RPM package (identical purl), reproducing
+    # the CUDA build case (libcublas.so.13 and libcublas.so.13.1.1.3 both
+    # come from libcublas-13-0).
+    libcublas = ProvidedBy(
+        package_type="rpm",
+        package_name="libcublas",
+        package_version="13.1.1.3-1",
+        distro="almalinux",
+    )
+    wheel_fname = "testpackage-0.0.1-py3-none-any.whl"
+
+    whichprovides.return_value = {
+        "/lib/libcublas.so.13": libcublas,
+        "/lib/libcublas.so.13.1.1.3": libcublas,
+    }
+    sbom_a = create_sbom_for_wheel(
+        wheel_fname,
+        [Path("/lib/libcublas.so.13"), Path("/lib/libcublas.so.13.1.1.3")],
+    )
+
+    # Different insertion order (e.g. different PYTHONHASHSEED). Since purl
+    # is identical for both files, only the filepath tie-break keeps this
+    # deterministic.
+    whichprovides.return_value = {
+        "/lib/libcublas.so.13.1.1.3": libcublas,
+        "/lib/libcublas.so.13": libcublas,
+    }
+    sbom_b = create_sbom_for_wheel(
+        wheel_fname,
+        [Path("/lib/libcublas.so.13.1.1.3"), Path("/lib/libcublas.so.13")],
+    )
+
+    assert sbom_a is not None
+    assert sbom_a == sbom_b
+
+    bom_refs = [c["bom-ref"] for c in sbom_a["components"][1:]]
+    assert bom_refs == sorted(bom_refs)


### PR DESCRIPTION
Fixes #729

I also added a test (`test_create_sbom_component_order_is_deterministic`) that feeds `whichprovides()` the same components in two different insertion orders and asserts the resulting SBOM is identical either way. I confirmed it fails without the fix and passes with it, and the full test suite passes.