### PR TITLE
Prepare 6.8.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## HEAD
 
+## 6.8.2
+
+Released August 30, 2026
+
+### User-facing changes
+- [BUGFIX] sort SBOM components deterministically ([#730](https://github.com/pypa/auditwheel/pull/730), [#729](https://github.com/pypa/auditwheel/issues/729))
+
 ## 6.8.1
 
 Released August 15, 2026


### PR DESCRIPTION
## 6.8.2

Released August 30, 2026

### User-facing changes
- [BUGFIX] sort SBOM components deterministically ([#730](https://github.com/pypa/auditwheel/pull/730), [#729](https://github.com/pypa/auditwheel/issues/729))
